### PR TITLE
Allow running basic OpenShift testing scenarios

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,5 +100,14 @@ for dir in ${dirs}; do
     fi
   fi
 
+  if [[ -v TEST_OPENSHIFT_MODE ]]; then
+    if [[ -x test/run-openshift ]]; then
+      VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run-openshift
+    else
+      echo "-> OpenShift tests are not present, skipping"
+    fi
+  fi
+
+
   popd > /dev/null
 done

--- a/common.mk
+++ b/common.mk
@@ -28,3 +28,7 @@ build:
 .PHONY: test
 test:
 	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)
+
+.PHONY: test-openshift
+test-openshift:
+	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_OPENSHIFT_MODE=true $(build)


### PR DESCRIPTION
I would like add some simple scripts to test images in OpenShift environment.

It is quite easy to deploy OpenShift with `oc cluster up` and having these simple tests would allow developers/users to easily test changes or to add this testing to CI.

This PR adds new make target `test-openshift` - by it images are built and `test/run-openshift` is run (if exists), it is similar how `make test` is handled.

Testing changes in OpenShift is not necessary for all code changes, so IMPOV it could be better to haveseparate make target for it.

@praiskup Please take a look.