### PR TITLE
Use s2i instead of sti

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ DOCKERFILE_PATH=""
 
 test -z "$BASE_IMAGE_NAME" && {
   BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-[0-9]*$//g')
-  BASE_IMAGE_NAME="${BASE_DIR_NAME#sti-}"
+  BASE_IMAGE_NAME="${BASE_DIR_NAME#s2i-}"
 }
 
 # Cleanup the temporary Dockerfile created by docker build with version


### PR DESCRIPTION
S2i based images have this line - for example https://github.com/sclorg/s2i-base-container/blob/master/hack/build.sh#L13
This change is needed to be able to add this repo into s2i based images - s2i-python-container, s2i-nodejs-container,...

@praiskup Please review.