### PR TITLE
Move help.1 file into a root/ subdirectory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,6 @@ function docker_build_with_version {
   # Use perl here to make this compatible with OSX
   DOCKERFILE_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' $dockerfile)
   cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
-  echo "COPY help.1 /" >> "${dockerfile}.version"
   git_version=$(git rev-parse --short HEAD)
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
   if [[ "${UPDATE_BASE}" == "1" ]]; then

--- a/common.mk
+++ b/common.mk
@@ -35,7 +35,7 @@ test: manpages
 test-openshift: manpages
 	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_OPENSHIFT_MODE=true $(build)
 
-manpages = $(shell for version in $(VERSIONS); do echo "$$version/help.1"; done)
+manpages = $(shell for version in $(if $(VERSION), $(VERSION), $(VERSIONS)); do echo "$$version/help.1"; done)
 manpages: $(manpages)
 $(manpages): %help.1: %README.md
 	go-md2man -in "$^" -out "$@"

--- a/common.mk
+++ b/common.mk
@@ -35,7 +35,9 @@ test: manpages
 test-openshift: manpages
 	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_OPENSHIFT_MODE=true $(build)
 
-manpages = $(shell for version in $(if $(VERSION), $(VERSION), $(VERSIONS)); do echo "$$version/help.1"; done)
+manpages = $(shell for version in $(if $(VERSION), $(VERSION), $(VERSIONS)); \
+		do echo "$$version/root/help.1"; done)
 manpages: $(manpages)
-$(manpages): %help.1: %README.md
+$(manpages): %root/help.1: %README.md
+	mkdir -p $(@D)
 	go-md2man -in "$^" -out "$@"


### PR DESCRIPTION
Continuing upon the pull request #7, the help.1 file is now generated into a `root` subdirectory (which is first created should it not exist yet) and then an instruction is added to copy all contents of the `root` directory to the `/` root of the image.

s2i based images can now move the contents of their `contrib` directory into `root/opt/app-root` instead, which will then be copied automatically.

_I've also included a small bug fix of the `manpages` macro to account for the `VERSION` parameter correctly._