### PR TITLE
[WIP] Do not use VERSION and VERSIONS for the same purpose in common.mk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,12 +66,5 @@ for dir in ${dirs}; do
     docker_build_with_version Dockerfile
   fi
 
-  ok_to_tag=1
-  if [[ $ok_to_tag -eq 1 ]]; then
-    echo "-> Tagging image to '$name:$version' and '$name:latest'"
-    docker tag $IMAGE_NAME "$name:$version"
-    docker tag $IMAGE_NAME "$name:latest"
-  fi
-
   popd > /dev/null
 done

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,6 @@ function docker_build_with_version {
   local docker_cmd=(docker build ${BUILD_OPTIONS} -f "${dockerfile}" .)
   { IMAGE_ID=$("${docker_cmd[@]}" | tee /dev/fd/$fd | awk '/Successfully built/{print $NF}'); } {fd}>&1
 
-  echo $IMAGE_ID >.image-id
   name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
 
   IMAGE_NAME=$name
@@ -40,6 +39,7 @@ function docker_build_with_version {
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}"
   fi
+  docker images $IMAGE_NAME -q >.image-id
 }
 
 # Install the docker squashing tool[1] and squash the result image

--- a/common.mk
+++ b/common.mk
@@ -17,26 +17,24 @@ endif
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
-	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
-	VERSION="$(VERSION)"                            \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 
 .PHONY: build
-build: manpages
-	$(script_env) $(build)
+build: $(VERSIONS)
+
+.PHONY: $(VERSIONS)
+$(VERSIONS): % : %/root/help.1
+	VERSION="$@" $(script_env) $(build)
 
 .PHONY: test
-test: manpages
-	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)
+test: script_env += TEST_MODE=true
+test: $(VERSIONS)
 
 .PHONY: test-openshift
-test-openshift: manpages
-	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_OPENSHIFT_MODE=true $(build)
+test-openshift: script_env += TEST_OPENSHIFT_MODE=true
+test-openshift: $(VERSIONS)
 
-manpages = $(shell for version in $(if $(VERSION), $(VERSION), $(VERSIONS)); \
-		do echo "$$version/root/help.1"; done)
-manpages: $(manpages)
-$(manpages): %root/help.1: %README.md
+%root/help.1: %README.md
 	mkdir -p $(@D)
 	go-md2man -in "$^" -out "$@"

--- a/common.mk
+++ b/common.mk
@@ -6,6 +6,7 @@ endif
 
 build = $(common_dir)/build.sh
 test = $(common_dir)/test.sh
+tag = $(common_dir)/tag.sh
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
@@ -23,6 +24,7 @@ script_env = \
 
 .PHONY: build
 build: $(VERSIONS)
+	VERSIONS="$(VERSIONS)" $(script_env) $(tag)
 
 .PHONY: $(VERSIONS)
 $(VERSIONS): % : %/root/help.1
@@ -32,11 +34,13 @@ $(VERSIONS): % : %/root/help.1
 test: script_env += TEST_MODE=true
 test: $(VERSIONS)
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
+	VERSIONS="$(VERSIONS)" $(script_env) $(tag)
 
 .PHONY: test-openshift
 test-openshift: script_env += TEST_OPENSHIFT_MODE=true
 test-openshift: $(VERSIONS)
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
+	VERSIONS="$(VERSIONS)" $(script_env) $(tag)
 
 %root/help.1: %README.md
 	mkdir -p $(@D)

--- a/common.mk
+++ b/common.mk
@@ -5,6 +5,7 @@ ifndef common_dir
 endif
 
 build = $(common_dir)/build.sh
+test = $(common_dir)/test.sh
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
@@ -30,10 +31,12 @@ $(VERSIONS): % : %/root/help.1
 .PHONY: test
 test: script_env += TEST_MODE=true
 test: $(VERSIONS)
+	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
 .PHONY: test-openshift
 test-openshift: script_env += TEST_OPENSHIFT_MODE=true
 test-openshift: $(VERSIONS)
+	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
 %root/help.1: %README.md
 	mkdir -p $(@D)

--- a/tag.sh
+++ b/tag.sh
@@ -16,7 +16,7 @@ for dir in ${VERSIONS}; do
   if [[ -v TEST_MODE ]]; then
     IMAGE_NAME+="-candidate"
   fi
-  echo "-> Tagging image to '$name:$version' and '$name:latest'"
+  echo "-> Tagging image '$IMAGE_NAME' as '$name:$version' and '$name:latest'"
   docker tag $IMAGE_NAME "$name:$version"
   docker tag $IMAGE_NAME "$name:latest"
 

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+# This script is used to tag the OpenShift Docker images.
+#
+# Resulting image will be tagged: 'name:version' and 'name:latest'. Name and version
+#                                  are values of labels from resulted image
+#
+# TEST_MODE - If set, the script will look for *-candidate images to tag
+# VERSIONS - Must be set to a list with possible versions (subdirectories)
+
+for dir in ${VERSIONS}; do
+  pushd ${dir} > /dev/null
+  IMAGE_ID=$(cat .image-id)
+  name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
+  version=$(docker inspect -f "{{.Config.Labels.version}}" $IMAGE_ID)
+  IMAGE_NAME=$name
+  if [[ -v TEST_MODE ]]; then
+    IMAGE_NAME+="-candidate"
+  fi
+  echo "-> Tagging image to '$name:$version' and '$name:latest'"
+  docker tag $IMAGE_NAME "$name:$version"
+  docker tag $IMAGE_NAME "$name:latest"
+
+  rm .image-id
+  popd > /dev/null
+done

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+# This script is used to test the OpenShift Docker images.
+#
+# TEST_MODE - If set, run regular test suite
+# TEST_OPENSHIFT_MODE - If set, run OpenShift tests (if present)
+# VERSIONS - Must be set to a list with possible versions (subdirectories)
+
+for dir in ${VERSIONS}; do
+  pushd ${dir} > /dev/null
+  IMAGE_ID=$(cat .image-id)
+  name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
+  IMAGE_NAME=$name"-candidate"
+
+  if [[ -v TEST_MODE ]]; then
+    VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run
+  fi
+
+  if [[ -v TEST_OPENSHIFT_MODE ]]; then
+    if [[ -x test/run-openshift ]]; then
+      VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run-openshift
+    else
+      echo "-> OpenShift tests are not present, skipping"
+    fi
+  fi
+
+  popd > /dev/null
+done


### PR DESCRIPTION
Instead only use VERSIONS to choose which versions of the image to build in the makefile
and depend on its rules for populating the VERSION variable to be used in build.sh

Based on https://github.com/sclorg/postgresql-container/pull/152