### PR TITLE
Get tag of resulted image from name and version labels

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ for dir in ${dirs}; do
     docker tag $IMAGE_NAME "$name:latest"
   fi
 
-  docker rmi $IMAGE_NAME
+  docker rmi --no-prune $IMAGE_NAME
 
   popd > /dev/null
 done

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ function docker_build_with_version {
   if [[ -v TEST_MODE ]]; then
     IMAGE_NAME+="-candidate"
   fi
+  echo "-> Image ${IMAGE_ID} tagged as ${IMAGE_NAME}"
   docker tag $IMAGE_ID $IMAGE_NAME
 
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
@@ -71,7 +72,7 @@ for dir in ${dirs}; do
   ok_to_tag=1
   if [[ -v TEST_MODE ]]; then
     VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run
-    if [[ $? -ne 0 ]] || [[ "${TAG_ON_SUCCESS}" != "true" ]]; then
+    if [[ "${TAG_ON_SUCCESS}" != "true" ]]; then
       ok_to_tag=0
     fi
   fi

--- a/build.sh
+++ b/build.sh
@@ -27,9 +27,8 @@ function docker_build_with_version {
     BUILD_OPTIONS+=" --pull=true"
   fi
 
-  docker build ${BUILD_OPTIONS} -f "${dockerfile}" . | tee build.log
-  local IMAGE_ID=$(cat build.log | awk '/Successfully built/{print $NF}')
-  rm build.log
+  local docker_cmd=(docker build ${BUILD_OPTIONS} -f "${dockerfile}" .)
+  { IMAGE_ID=$("${docker_cmd[@]}" | tee /dev/fd/$fd | awk '/Successfully built/{print $NF}'); } {fd}>&1
 
   name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
   version=$(docker inspect -f "{{.Config.Labels.version}}" $IMAGE_ID)

--- a/common.mk
+++ b/common.mk
@@ -20,7 +20,6 @@ script_env = \
 	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
 	VERSION="$(VERSION)"                            \
-	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 
 .PHONY: build


### PR DESCRIPTION
Get tag of resulted image from `name` and `version` labels

Earch sclorg/ image should contain `name` and `version` labels (Atomic Best Practices recommends it, Fedora requires it). These labels can be used to tag the image - OSBS does the same.

So with this change there is no need for getting `NAMESPACE` from `TARGET`, `BASE_IMAGE_NAME` from `pwd`,...

@pkubatrh @torsava @praiskup Please take a look.