### PR TITLE
Fix squashing - docker-squash does not tag image by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,9 +42,9 @@ function docker_build_with_version {
 function squash {
   # FIXME: We have to use the exact versions here to avoid Docker client
   #        compatibility issues
-  easy_install -q --user docker_py==1.7.2 docker-squash==1.0.1
+  easy_install -q --user docker_py==1.10.6 docker-squash==1.0.5
   base=$(awk '/^FROM/{print $2}' $1)
-  ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME}
+  ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME} -t ${IMAGE_NAME}
 }
 
 # Versions are stored in subdirectories. You can specify VERSION variable


### PR DESCRIPTION
Fix squashing - docker-squash does not tag image by default (it proclaims it - `By default it'll be set to 'image' argument`)

In current situation squashing is done, but the resulted image is not tagged. So testing is done with unsquashed image.

Also updated docker-squash

https://github.com/sclorg/s2i-base-container/pull/110 aims also to update to docker squash. It also brings a  change that image is build with `-unsquashed` suffix and after squashing this image is removed.
I'm against this change, because it "cleans" docker build cache and slows down builds. But it option too. Opinions?

@pkubatrh @praiskup @torsava Please take a look and merge.