### PR TITLE
Add a common test file shared among all containers

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -25,16 +25,16 @@ EXPECTED_EXIT_CODE=0
 # Uses: $EXPECTED_EXIT_CODE - expected container exit code
 function ct_cleanup() {
   for cid_file in $CID_FILE_DIR/* ; do
-    local CONTAINER=$(cat $cid_file)
+    local container=$(cat $cid_file)
 
-    : "Stopping and removing container $CONTAINER..."
-    docker stop $CONTAINER
-    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $CONTAINER)
+    : "Stopping and removing container $container..."
+    docker stop $container
+    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $container)
     if [ "$exit_status" != "$EXPECTED_EXIT_CODE" ]; then
-      : "Dumping logs for $CONTAINER"
-      docker logs $CONTAINER
+      : "Dumping logs for $container"
+      docker logs $container
     fi
-    docker rm $CONTAINER
+    docker rm $container
     rm $cid_file
   done
   rmdir $CID_FILE_DIR
@@ -141,7 +141,7 @@ function ct_create_container() {
   : "Created container $(cat $cid_file)"
 }
 
-# ctest_scl_usage [name, command, expected]
+# ct_scl_usage_old [name, command, expected]
 # --------------------
 # Tests three ways of running the SCL, by looking for an expected string
 # in the output of the command
@@ -150,7 +150,7 @@ function ct_create_container() {
 # Argument: expected - string that is expected to be in the command output
 # Uses: $CID_FILE_DIR - path to directory containing cid_files
 # Uses: $IMAGE_NAME - name of the image being tested
-function ctest_scl_usage() {
+function ct_scl_usage_old() {
   local name="$1"
   local run_cmd="$2"
   local expected="$3"
@@ -173,13 +173,13 @@ function ctest_scl_usage() {
   fi
 }
 
-# ctest_doc_content [strings]
+# ct_doc_content_old [strings]
 # --------------------
 # Looks for occurence of stirngs in the documentation files and checks
 # the format of the files. Files examined: help.1
 # Argument: strings - strings expected to appear in the documentation
 # Uses: $IMAGE_NAME - name of the image being tested
-function ctest_doc_content() {
+function ct_doc_content_old() {
   local tmpdir=$(mktemp -d)
   local f
   : "  Testing documentation in the container image"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -87,6 +87,29 @@ function concit_create_container() {
   concit_wait_for_cid
 }
 
+function concit_scl_usage() {
+  local name="$1"
+  local run_cmd="$2"
+  local expected="$3"
+
+  : "  Testing the image SCL enable"
+  out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(get_cid $name) /bin/bash -c "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(get_cid $name) /bin/sh -ic "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+}
+
 function concit_run_doc_test() {
   local tmpdir=$(mktemp -d)
   local f

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,113 @@
+#
+# Test a container image.
+#
+# Always use sourced from a specific container testfile 
+#
+# reguires definition of CID_FILE_DIR
+# CID_FILE_DIR=$(mktemp --suffix=<container>_test_cidfiles -d)
+# reguires definition of TEST_LIST 
+# TEST_LIST="\
+# run_container_creation_tests
+# run_doc_test <words_to_look_for_in_the_doc>"
+
+# may be redefined in the specific container testfile
+EXPECTED_EXIT_CODE=0
+
+function cleanup() {
+  for cid_file in $CID_FILE_DIR/* ; do
+    CONTAINER=$(cat $cid_file)
+
+    : "Stopping and removing container $CONTAINER..."
+    docker stop $CONTAINER
+    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $CONTAINER)
+    if [ "$exit_status" != "$EXPECTED_EXIT_CODE" ]; then
+      : "Dumping logs for $CONTAINER"
+      docker logs $CONTAINER
+    fi
+    docker rm $CONTAINER
+    rm $cid_file
+  done
+  rmdir $CID_FILE_DIR
+  : "Done."
+}
+trap cleanup EXIT SIGINT
+
+function get_cid() {
+  local name="$1" ; shift || return 1
+  echo $(cat "$CID_FILE_DIR/$name")
+}
+
+function get_container_ip() {
+  local id="$1" ; shift
+  docker inspect --format='{{.NetworkSettings.IPAddress}}' $(get_cid "$id")
+}
+
+function wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    : "Waiting for container start..."
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+# Make sure the invocation of docker run fails.
+function assert_container_creation_fails() {
+
+  # Time the docker run command. It should fail. If it doesn't fail,
+  # container will keep running so we kill it with SIGKILL to make sure
+  # timeout returns a non-zero value.
+  set +e
+  timeout -s SIGTERM --preserve-status 10s docker run --rm "$@" $IMAGE_NAME
+  ret=$?
+  set -e
+
+  # Timeout will exit with a high number.
+  if [ $ret -gt 128 ]; then
+    return 1
+  fi
+}
+
+# to pass some arguments you need to specify CONTAINER_ARGS variable
+function create_container() {
+  cid_file="$CID_FILE_DIR/$1" ; shift
+  # create container with a cidfile in a directory for cleanup
+  docker run ${CONTAINER_ARGS:-} --cidfile="$cid_file" -d $IMAGE_NAME "$@"
+  : "Created container $(cat $cid_file)"
+  wait_for_cid
+}
+
+function run_doc_test() {
+  local tmpdir=$(mktemp -d)
+  local f
+  : "  Testing documentation in the container image"
+  # Extract the help files from the container
+  for f in help.1 ; do
+    docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /${f}" >${tmpdir}/$(basename ${f})
+    # Check whether the files contain some important information
+    for term in $@ ; do
+      if ! cat ${tmpdir}/$(basename ${f}) | grep -F -q -e "${term}" ; then
+        echo "ERROR: File /${f} does not include '${term}'."
+        return 1
+      fi
+    done
+  done
+  # Check whether the files use the correct format
+  if ! file ${tmpdir}/help.1 | grep -q roff ; then
+    echo "ERROR: /help.1 is not in troff or groff format"
+    return 1
+  fi
+  : "  Success!"
+}
+
+function run_all_tests() {
+  for test_case in $TEST_LIST; do
+    : "Running test $test_case"
+    $test_case
+  done;
+}
+


### PR DESCRIPTION
This file contains common bits for container tests, and should be sourced by each specific container test. It is created to keep the code on one place and not spread through the repositories.