### PR TITLE
Add option to cleanup built images and containers created by tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ function docker_build_with_version {
   docker tag $IMAGE_ID $IMAGE_NAME
 
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
+    docker tag $IMAGE_ID "${IMAGE_NAME}-unsquashed"
     squash "${dockerfile}"
   fi
   # Narrow by repo:tag first and then grep out the exact match

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,8 @@ function docker_build_with_version {
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}"
   fi
-  docker images $IMAGE_NAME -q >.image-id
+  # Narrow by repo:tag first and then grep out the exact match
+  docker images "${IMAGE_NAME}:latest" --format="{{.Repository}} {{.ID}}" | grep "^${IMAGE_NAME}" | awk '{print $2}' >.image-id
 }
 
 # Install the docker squashing tool[1] and squash the result image

--- a/common.mk
+++ b/common.mk
@@ -20,6 +20,7 @@ script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
 	OS=$(OS)                                        \
+	CLEAN_AFTER=$(CLEAN_AFTER)                      \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 
 .PHONY: build

--- a/tag.sh
+++ b/tag.sh
@@ -7,7 +7,9 @@
 # TEST_MODE - If set, the script will look for *-candidate images to tag
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
 # CLEAN_AFTER - If set the script will clean built up leftover images and
-#               containers created during the run of the test suite
+#               containers created during the run of the test suite.
+#               If set to the string "all" it will additionally remove
+#               the original (unsquashed) image.
 
 for dir in ${VERSIONS}; do
   pushd ${dir} > /dev/null
@@ -25,10 +27,8 @@ for dir in ${VERSIONS}; do
     docker rm $(docker ps -q -a -f "ancestor=$IMAGE_ID") 2>/dev/null || :
     # Remove the built image
     docker rmi $IMAGE_ID --force 2>/dev/null || :
-    # Remove all untagged images
-    docker rmi $(docker images -q -f "dangling=true") 2>/dev/null || :
-    # Remove all remaining volumes not referenced by any container
-    docker volume rm $(docker volume ls -q -f "dangling=true") 2>/dev/null || :
+    # Remove the unsquashed image
+    [ "$CLEAN_AFTER" == "all" ] && docker rmi "${IMAGE_NAME}-unsquashed" 2>/dev/null || :
  else
     echo "-> Tagging image '$IMAGE_NAME' as '$name:$version' and '$name:latest'"
     docker tag $IMAGE_NAME "$name:$version"


### PR DESCRIPTION
I have added the clean-up code to `tag.sh` since that seemed like the best place to me (either tag the results or remove them).

Currently the clean-up code removes:
- All leftover containers that have been created from the built image
- The built image (squashed image when not using SKIP_SQUASH)
- All untagged images (unsquashed image when not using SKIP_SQUASH)
- All volumes that are no longer referenced by any container

I know @omron93 mentioned somewhere that removing the un-squashed image might make the PR CI slower since the build cache is removed by doing this. Do we want to keep the un-squashed images for the sake of speed-up?