### PR TITLE
More logical buildsystem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,6 @@
 #
 # OS - Specifies distribution - "rhel7", "centos7" or "fedora"
 # VERSION - Specifies the image version - (must match with subdirectory in repo)
-# TAG_ON_SUCCESS - If set, tested image will be re-tagged as a non-candidate
-#       image, if the tests pass.
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
 
 OS=${1-$OS}

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+set -e
+for version
+do
+    remove_images=
+    for idfile in .image-id.raw .image-id.squashed; do
+        test ! -f "$version/$idfile" || remove_images+=" $(cat "$version/$idfile")"
+    done
+
+    for image in $remove_images; do
+        docker rm -f $(docker ps -q -a -f "ancestor=$image") 2>/dev/null || :
+        docker rmi -f "$image" || :
+    done
+
+    rm -rf "$version"/.image-id*
+done

--- a/common.mk
+++ b/common.mk
@@ -50,7 +50,9 @@ build-all: $(VERSIONS)
 $(VERSIONS): % : %/root/help.1
 	VERSION="$@" $(script_env) $(build)
 
-.PHONY: test
+.PHONY: test check
+check: test
+
 test: script_env += TEST_MODE=true
 
 # The tests should ideally depend on $IMAGE_ID only, but see PR#19 for more info

--- a/common.mk
+++ b/common.mk
@@ -13,6 +13,7 @@ tag = $(common_dir)/tag.sh
 clean = $(common_dir)/clean.sh
 
 ifeq ($(TARGET),rhel7)
+	SKIP_SQUASH ?= 0
 	OS := rhel7
 	DOCKERFILE ?= Dockerfile.rhel7
 else ifeq ($(TARGET),fedora)
@@ -22,6 +23,8 @@ else
 	OS := centos7
 	DOCKERFILE ?= Dockerfile
 endif
+
+SKIP_SQUASH ?= 1
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \

--- a/common.mk
+++ b/common.mk
@@ -74,3 +74,4 @@ clean:
 %root/help.1: %README.md
 	mkdir -p $(@D)
 	go-md2man -in "$^" -out "$@"
+	chmod a+r "$@"

--- a/tag.sh
+++ b/tag.sh
@@ -4,7 +4,6 @@
 # Resulting image will be tagged: 'name:version' and 'name:latest'. Name and version
 #                                  are values of labels from resulted image
 #
-# TEST_MODE - If set, the script will look for *-candidate images to tag
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
 
 for dir in ${VERSIONS}; do
@@ -13,9 +12,6 @@ for dir in ${VERSIONS}; do
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
   version=$(docker inspect -f "{{.Config.Labels.version}}" $IMAGE_ID)
-  if [ -n "${TEST_MODE}" ]; then
-    name+="-candidate"
-  fi
 
   echo "-> Tagging image '$IMAGE_ID' as '$name:$version' and '$name:latest'"
   docker tag $IMAGE_ID "$name:$version"

--- a/test.sh
+++ b/test.sh
@@ -8,17 +8,17 @@
 for dir in ${VERSIONS}; do
   [ ! -e "${dir}/.image-id" ] && echo "-> Image for version $dir not built, skipping tests." && continue
   pushd ${dir} > /dev/null
-  IMAGE_ID=$(cat .image-id)
-  name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
-  IMAGE_NAME=$name"-candidate"
+  export IMAGE_ID=$(cat .image-id)
+  # Kept also IMAGE_NAME as some tests might still use that.
+  export IMAGE_NAME=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
 
   if [ -n "${TEST_MODE}" ]; then
-    VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run
+    VERSION=$dir test/run
   fi
 
   if [ -n "${TEST_OPENSHIFT_MODE}" ]; then
     if [[ -x test/run-openshift ]]; then
-      VERSION=$dir IMAGE_NAME=${IMAGE_NAME} test/run-openshift
+      VERSION=$dir test/run-openshift
     else
       echo "-> OpenShift tests are not present, skipping"
     fi


### PR DESCRIPTION
Use more standardized "make" workflow
    
From now we don't blindly squash image if there are no changes
(aka docker build was no-op).  We also remove old (unreferenced
images if those are to be replaced by new images.
    
    `make` or `make build`
        Builds the images.
    
    `make tag`
        Tag built images (depends on `make build`).
    
    `make test`
        Tests the :latest image (build if necessary).  This depends on
        `make tag` because the existing test-cases out in the wild
        depend on tagged images.  The most importantly the s2i tool
        doesn't seem to work with $IMAGE_ID only.

The `make tag` also tags the image with `:squashed` or `:raw` suffixes,
while the `:latest` image points (only) to one of them.