### PR TITLE
Add EXCLUDE_VERSIONS to explicitly set which versions not to build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ DOCKERFILE_PATH=""
 # Perform docker build but append the LABEL with GIT commit id at the end
 function docker_build_with_version {
   local dockerfile="$1"
+  local exclude=.exclude-${OS}
+  [ -e $exclude ] && echo "-> $exclude file exists for version $dir, skipping build." && return
   [ ! -e "$dockerfile" ] && echo "-> $dockerfile for version $dir does not exist, skipping build." && return
   echo "-> Version ${dir}: building image from '${dockerfile}' ..."
 


### PR DESCRIPTION
This is connected to #4 . As we are now pushing towards having the whole git history available in a single directory (be-it `latest` or the highest version available so far) to use `git blame` easily, we need to make sure we are able to both keep the Dockerfile.version history when a new version is introduced (which is most likely going to be the latest one) and to make the tests not fail in case centos/rhel packages are still not ready for the new version.

Currently to make sure the tests do not fail we would have to remove the Dockerfile.version specific to the distribution which does not yet have the packages available. This would however get rid of the git history of the Dockerfile we have been trying to preserve. This PR aims to fix this problem by introducing `EXCLUDE_VERSIONS` to `common.mk` and `build.sh` that can be used to explicitly provide information on which versions for which distribution to ignore.

@hhorak @torsava @praiskup WDYT