### PR TITLE
build.sh: fix /dev/pts/ permission issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,41 @@ VERSION=${2-$VERSION}
 
 DOCKERFILE_PATH=""
 
+# parse_output COMMAND FILTER_COMMAND OUTVAR [STREAM]
+# ---------------------------------------------------
+# Parse stdout (STREAM='stdout') or stderr (STREAM='stdout') of COMMAND with
+# FILTER_COMMAND and store the output into variable named OUTVAR.
+# The filtered output stays (live) printed to terminal.  This method doesn't
+# create any explicit temporary files.
+# Defines:
+#   ${$OUTVAR}: Set to FILTER_COMMAND output.
+parse_output ()
+{
+  local command=$1 filter=$2 var=$3 stream=$4
+  local raw_output= rc=0
+  {
+      raw_output=$(
+        set -o pipefail
+        {
+            case $stream in
+            stdout|1|"")
+                eval "$command" | tee >(cat - >&$stdout_fd)
+                 ;;
+            stderr|2)
+                set +x # avoid stderr pollution
+                eval "$command" {free_fd}>&1 1>&$stdout_fd 2>&$free_fd | tee >(cat - >&$stderr_fd)
+                ;;
+            esac
+            # Inherit correct exit status.
+            (exit ${PIPESTATUS[0]})
+        } | eval "$filter"
+      )
+  } {stdout_fd}>&1 {stderr_fd}>&2
+  rc=$?
+  eval "$var=\$raw_output"
+  (exit $rc)
+}
+
 # Perform docker build but append the LABEL with GIT commit id at the end
 function docker_build_with_version {
   local dockerfile="$1"
@@ -27,8 +62,9 @@ function docker_build_with_version {
     BUILD_OPTIONS+=" --pull=true"
   fi
 
-  local docker_cmd=(docker build ${BUILD_OPTIONS} -f "${dockerfile}" .)
-  { IMAGE_ID=$("${docker_cmd[@]}" | tee /dev/fd/$fd | awk '/Successfully built/{print $NF}'); } {fd}>&1
+  parse_output 'docker build $BUILD_OPTIONS -f "$dockerfile" .' \
+               "awk '/Successfully built/{print \$NF}'" \
+               IMAGE_ID
 
   name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
 


### PR DESCRIPTION
The permissions/ownership of the /dev/pts/* file (symlinked from
/dev/fd/$fd) is uncertain, so we can not rely on the fact that we
can write to this file (happened to me when I ssh as 'root' to my
RHEL7 testing box and then I 'sudo su - foo').

Since we already depend on Bash features extensively, let's rather
let the shell allocate a temporary fifo file with >(cmd) feature.
While we are on it, separate the parsing method into self-standing
method which can be easily reused.