### PR TITLE
tests: execute remote container tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all:
+	@echo >&2 "Only 'make check' allowed"
+
+
+TESTED_IMAGES = \
+	postgresql-container \
+	s2i-python-container
+
+.PHONY: check test all
+test: check
+check:
+	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ Common build helpers for sclorg containers
 This repository is aimed to be added as git submodule into particular
 containers' source repositories.  By default, the path to submodule should be
 named 'common'.
+
+Regression tests
+----------------
+
+Just run `make check`
+
+Dependencies for testsuite:
+
+- docker
+- docker-squash (version 1.0.5)
+- git
+- go-md2man
+- make
+- source-to-image

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ VERSION=${2-$VERSION}
 
 DOCKERFILE_PATH=""
 
+error() { echo "ERROR: $*" ; false ; }
+
 # parse_output COMMAND FILTER_COMMAND OUTVAR [STREAM={stderr|stdout}]
 # -------------------------------------------------------------------
 # Parse standard (error) output of COMMAND with FILTER_COMMAND and store the
@@ -88,9 +90,11 @@ function docker_build_with_version {
 function squash {
   # FIXME: We have to use the exact versions here to avoid Docker client
   #        compatibility issues
-  easy_install -q --user docker-squash==1.0.5
+  local squash_version=1.0.5
+  test "$(docker-squash --version 2>&1)" = "$squash_version" || \
+      error "docker-squash $squash_version required"
   base=$(awk '/^FROM/{print $2}' $1)
-  ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME} -t ${IMAGE_NAME}
+  docker-squash -f $base ${IMAGE_NAME} -t ${IMAGE_NAME}
 }
 
 # Versions are stored in subdirectories. You can specify VERSION variable

--- a/tests/remote-containers.sh
+++ b/tests/remote-containers.sh
@@ -1,0 +1,94 @@
+#! /bin/bash
+
+declare -A IMAGES
+
+for image in ${TESTED_IMAGES}; do
+    IMAGES[$image]=master
+done
+
+OS=centos7
+
+MERGE_INTO=origin/master
+
+# This is the Fedora default, some users' boxes have more strict
+# defaults (e.g. 0077).
+umask 0022
+
+die ()   { echo >&2 " # FATAL: $*"; exit 1; }
+info ()  { echo     " * $*"; }
+error () { echo >&2 " # ERROR: $*"; }
+
+test -f common.mk -a -f build.sh -a -d .git \
+    || die "Doesn't seem to be run from common's git directory"
+
+analyse_commits ()
+{
+    # TODO: If we wanted to test "after PR merge", this needs to take some
+    # argument specifying how long we should look in the commit history.
+    git merge-base --is-ancestor "$MERGE_INTO" HEAD \
+        || die "Can not be --ff merged into $MERGE_INTO"
+
+    for commit in `git log --pretty=format:"%H" --reverse "$MERGE_INTO"..HEAD`
+    do
+        while read line; do
+            case $line in
+                Required-by:\ *)
+                    set -- $line
+                    old_IFS=$IFS
+                    IFS=\#
+                    set -- $2
+                    IFS=$old_IFS
+                    set -- $1 $2
+                    info "Commit $commit sets $1 to PR $2"
+                    IMAGES[$1]=$2
+                    ;;
+            esac
+        done < <(git show "$commit" --no-patch --pretty="%B")
+    done
+}
+
+analyse_commits
+
+rc=true
+for container in "${!IMAGES[@]}"; do
+    if test -e "$container"; then
+        rc=false
+        error "directory '$container' exists"
+        continue
+    fi
+
+    (   set -e
+        cleanup () { rm -rf "$container"; }
+        trap cleanup EXIT
+
+        info "Testing $container container"
+        # Use --recursive even if we remove 'common', because there might be
+        # other git submodules which need to be tested.
+
+        git clone --recursive -q https://github.com/sclorg/"$container".git
+        cd "$container"
+
+        revision=${IMAGES[$container]}
+        if ! test "$revision" = master; then
+            info "Fetching $container PR $revision"
+            git fetch origin "pull/$revision/head":PR_BRANCH
+            git checkout PR_BRANCH --recurse-submodules
+        fi
+
+        # We fail if the 'common' directory doesn't exist.
+        test -d common
+        rm -rf common
+        ln -s ../ common
+
+        # TODO: Do we have to test everything?
+        PS4="+ [$container] " make TARGET="$OS" test
+    )
+
+    # Note that '( set -e ; false ) || blah' doesn't work as one expects.
+    if test $? -ne 0; then
+        rc=false
+        error "Tests for $container failed"
+    fi
+done
+
+$rc


### PR DESCRIPTION
This is mainly for jenkins CI and it is only the first step
(turning on PostgreSQL tests for now)!  In future we should have
some local-only (and less expensive) tests, too.

Jenkins is only responsible for setting 'OS' variable (defaults to
centos7).

When some changes are needed in remote git repositories (say
PostgreSQL container) one have to first submit a pull request
against that git repository where one of the commits needs to
contain commit message with line of this format:

    Required-by: postgresql-container#111

.. where 'postgresql-container' is the name of project within
sclorg group, and '111' string is the id of already submitted pull
request.  Local testing against such pull-requests works too
(unless the actual branch is not yet merged into 'origin/master'
branch).