### PR TITLE
build: docker_py==1.10.6 not easily installable on RHEL7

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ function docker_build_with_version {
 function squash {
   # FIXME: We have to use the exact versions here to avoid Docker client
   #        compatibility issues
-  easy_install -q --user docker_py==1.10.6 docker-squash==1.0.5
+  easy_install -q --user docker-squash==1.0.5
   base=$(awk '/^FROM/{print $2}' $1)
   ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME} -t ${IMAGE_NAME}
 }


### PR DESCRIPTION
This pipy package fails to install because RHEL7 doesn't have
python 3 available by default:

  $ easy_install -q --user docker_py==1.10.6 docker-squash==1.0.5
  error: Setup script exited with error in docker-py setup
    command: Invalid environment marker: python_version < "3.5

But turns out we don't have to be that explicit about the
docker_py version nowadays.

Reverts: 5fe4cbbea27b2299e61e889f78414a9ec65ee70a
Fixes: #22