### PR TITLE
Allow to change the docker build context

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ function docker_build_with_version {
     BUILD_OPTIONS+=" --pull=true"
   fi
 
-  parse_output 'docker build $BUILD_OPTIONS -f "$dockerfile" .' \
+  parse_output 'docker build $BUILD_OPTIONS -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"' \
                "awk '/Successfully built/{print \$NF}'" \
                IMAGE_ID
 

--- a/common.mk
+++ b/common.mk
@@ -25,12 +25,14 @@ else
 endif
 
 SKIP_SQUASH ?= 1
+DOCKER_BUILD_CONTEXT ?= .
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
 	OS=$(OS)                                        \
 	CLEAN_AFTER=$(CLEAN_AFTER)                      \
+	DOCKER_BUILD_CONTEXT=$(DOCKER_BUILD_CONTEXT)    \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 
 # TODO: switch to 'build: build-all' once parallel builds are relatively safe


### PR DESCRIPTION
In order to allow sharing files in the parent directory, instead of having copies of the same files for every version, we need to be able to set the context of the docker build command for every image specifically. This change defines a new variables DOCKER_BUILD_CONTEXT that may be defined in the Makefile, typically to '..', so docker build will be run with the context of the parent directory.

@praiskup @pkubatrh Does this seem sane?