### PR TITLE
compat: avoid case statements in $()

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,32 @@ DOCKERFILE_PATH=""
 
 error() { echo "ERROR: $*" ; false ; }
 
+
+# _parse_output_inner
+# -------------------
+# Helper function for 'parse_output'.
+# We need to avoid case statements in $() for older Bash versions (per issue
+# postgresql-container#35, mac ships with 3.2).
+# Example of problematic statement: echo $(case i in i) echo i;; esac)
+_parse_output_inner ()
+{
+    set -o pipefail
+    {
+        case $stream in
+        stdout|1|"")
+            eval "$command" | tee >(cat - >&$stdout_fd)
+            ;;
+        stderr|2)
+            set +x # avoid stderr pollution
+            eval "$command" {free_fd}>&1 1>&$stdout_fd 2>&$free_fd | tee >(cat - >&$stderr_fd)
+            ;;
+        esac
+        # Inherit correct exit status.
+        (exit ${PIPESTATUS[0]})
+    } | eval "$filter"
+}
+
+
 # parse_output COMMAND FILTER_COMMAND OUTVAR [STREAM={stderr|stdout}]
 # -------------------------------------------------------------------
 # Parse standard (error) output of COMMAND with FILTER_COMMAND and store the
@@ -25,22 +51,7 @@ parse_output ()
   local command=$1 filter=$2 var=$3 stream=$4
   local raw_output= rc=0
   {
-      raw_output=$(
-        set -o pipefail
-        {
-            case $stream in
-            stdout|1|"")
-                eval "$command" | tee >(cat - >&$stdout_fd)
-                 ;;
-            stderr|2)
-                set +x # avoid stderr pollution
-                eval "$command" {free_fd}>&1 1>&$stdout_fd 2>&$free_fd | tee >(cat - >&$stderr_fd)
-                ;;
-            esac
-            # Inherit correct exit status.
-            (exit ${PIPESTATUS[0]})
-        } | eval "$filter"
-      )
+      raw_output=$(_parse_output_inner)
   } {stdout_fd}>&1 {stderr_fd}>&2
   rc=$?
   eval "$var=\$raw_output"


### PR DESCRIPTION
This is because mac still ships with obsoleted /bin/bash v3.

Fixes: #35