### PR TITLE
Distgen - support for image generation

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 set -e
+test -f auto_targets.mk && rm auto_targets.mk
+
 for version
 do
     remove_images=

--- a/common.mk
+++ b/common.mk
@@ -13,24 +13,30 @@ build = $(SHELL) $(common_dir)/build.sh
 test =  $(SHELL) $(common_dir)/test.sh
 tag =   $(SHELL) $(common_dir)/tag.sh
 clean = $(SHELL) $(common_dir)/clean.sh
+generator = $(SHELL) $(common_dir)/generate.sh
 
 ifeq ($(TARGET),rhel7)
 	SKIP_SQUASH ?= 0
 	OS := rhel7
 	DOCKERFILE ?= Dockerfile.rhel7
+	DG_CONF := rhel-7-x86_64.yaml
 else ifeq ($(TARGET),fedora)
 	OS := fedora
 	DOCKERFILE ?= Dockerfile.fedora
+	DG_CONF := fedora-27-x86_64.yaml
 else ifeq ($(TARGET),centos6)
 	OS := centos6
 	DOCKERFILE ?= Dockerfile.centos6
 else
 	OS := centos7
 	DOCKERFILE ?= Dockerfile
+	DG_CONF ?= centos-7-x86_64.yaml
 endif
 
 SKIP_SQUASH ?= 1
 DOCKER_BUILD_CONTEXT ?= .
+DISTGEN_BIN ?= /usr/bin/dg
+MANIFEST_FILE ?= manifest.sh
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
@@ -40,6 +46,11 @@ script_env = \
 	DOCKER_BUILD_CONTEXT=$(DOCKER_BUILD_CONTEXT)    \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"  \
 	CUSTOM_REPO="$(CUSTOM_REPO)"
+
+generation_env = \
+	DG_CONF=$(DG_CONF) \
+	DG=$(DISTGEN_BIN) \
+	MANIFEST_FILE=$(MANIFEST_FILE)
 
 # TODO: switch to 'build: build-all' once parallel builds are relatively safe
 .PHONY: build build-serial build-all
@@ -85,3 +96,17 @@ clean:
 	mkdir -p $(@D)
 	go-md2man -in "$^" -out "$@"
 	chmod a+r "$@"
+
+.PHONY: generate
+generate:
+	@$(MAKE) auto_targets.mk
+	@$(MAKE) exec-gen-rules
+	rm auto_targets.mk
+
+auto_targets.mk: $(generator) $(MANIFEST_FILE)
+	VERSIONS="$(VERSIONS)" $(generation_env) $(generator)
+
+include auto_targets.mk
+
+.PHONY: exec-gen-rules
+exec-gen-rules: $(DISTGEN_TARGETS) $(COPY_TARGETS) $(SYMLINK_TARGETS)

--- a/gen.mk
+++ b/gen.mk
@@ -1,0 +1,27 @@
+# Helper for generating image repository files
+
+ifndef common_dir
+    common_dir = common
+endif
+
+generator = $(common_dir)/generate.sh
+# default path for dg binary from package distgen
+DISTGEN_BIN ?= /usr/bin/dg
+MANIFEST_FILE ?= manifest.sh
+
+generation_env = \
+	DG=$(DISTGEN_BIN) \
+	MANIFEST_FILE=$(MANIFEST_FILE)
+
+.PHONY: gen
+gen: auto_targets.mk exec-gen-rules
+	rm auto_targets.mk
+
+
+auto_targets.mk: $(generator) $(MANIFEST_FILE)
+	VERSIONS="$(VERSIONS)" DG_CONF="$(DG_CONF)" $(generation_env) $(generator)
+
+include auto_targets.mk
+
+.PHONY: exec-gen-rules
+exec-gen-rules: $(DISTGEN_TARGETS) $(COPY_TARGETS) $(SYMLINK_TARGETS)

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# This script is used to create image directories using distgen, cp or ln
+# It requires manifest.sh file to be present in image repository
+# The manifest file should contain set of rules in form:
+# <rules_type>="
+# src=<path to source>
+# dest=<path to destination>
+# mode=<destination file mode (optional)>;
+# ...;
+# "
+#
+# Supported type rules are now COPY_RULES, DISTGEN_RULES and SYMLINKS_RULES
+# for real example see https://github.com/sclorg/postgresql-container/blob/master/manifest.sh
+
+source manifest.sh
+
+test -f auto_targets.mk && rm auto_targets.mk
+
+DESTDIR="${DESTDIR:-$PWD}"
+
+clean_rule_variables(){
+    src=""
+    dest=""
+    mode=""
+    link_target=""
+    link_name=""
+}
+
+parse_rules() {
+    targets=""
+    OLD_IFS=$IFS
+    IFS=";"
+    for rule in $rules; do
+        if [ -z $(echo "$rule"| tr -d '[:space:]') ]; then
+            continue
+        fi
+        clean_rule_variables
+        eval $rule
+
+        case "$creator" in
+            copy)
+                [[ -z "$src" ]] && echo "src has to be specified in copy rule" && exit 1
+                [[ -z "$dest" ]] && echo "dest has to be specified in copy rule" && exit 1
+                core_subst=$core
+                ;;
+            distgen)
+                [[ -z "$src" ]] && echo "src has to be specified in distgen rule" && exit 1
+                [[ -z "$dest" ]] && echo "dest has to be specified in distgen rule" && exit 1
+                core_subst=$core
+                ;;
+            link)
+                [[ -z "$link_name" ]] && echo "link_name has to be specified in link rule" && exit 1
+                [[ -z "$link_target" ]] && echo "link_target has to be specified in link rule" && exit 1
+                dest="$link_name"
+                core_subst=$(echo $core | sed -e "s~__link_target__~"${link_target}"~g")
+                ;;
+        esac
+        t=$(echo ${DESTDIR}/${version}/${dest} | sed 's/ /\\ /g')
+        src=$(echo $src | sed 's/ /\\ /g' )
+        targets+="	$t \\
+"
+        cat >> auto_targets.mk << EOF
+$t: $src manifest.sh
+	@echo ${message} ; \\
+	mkdir -p "\$\$(dirname \$@)" || exit 1 ; \\
+	${core_subst}
+    ${mode:+"chmod ${mode} "\$@""}
+
+EOF
+    done
+    IFS=$OLD_IFS
+}
+
+for version in ${VERSIONS}; do
+    # copy targets
+    rules="$COPY_RULES"
+    core="cp \$< \$@ ; \\"
+    message="Copying \"\$@\""
+    creator="copy"
+    parse_rules
+    COPY_TARGETS+="$targets"
+
+
+    # distgen targets
+    rules="$DISTGEN_RULES"
+    core="${DG} --multispec specs/multispec.yml \\
+	--template \"\$<\" --distro \"$DG_CONF\" \\
+	--multispec-selector version=\"$version\" --output \"\$@\" ; \\"
+    message="Generating \"\$@\" using distgen"
+    creator="distgen"
+    parse_rules
+    DISTGEN_TARGETS+="$targets"
+
+
+    rules=$SYMLINK_RULES
+    core="ln -fs __link_target__ \$@ ; \\"
+    message="Creating symlink \"\$@\""
+    creator="link"
+    parse_rules
+    SYMLINK_TARGETS+="$targets"
+done
+
+    # adding COPY_TARGETS variable at the bottom of auto_targets.mk file
+    cat -v >> auto_targets.mk << EOF
+COPY_TARGETS = \\
+$COPY_TARGETS
+EOF
+
+    # adding DISTGEN_TARGETS variable at the bottom of auto_targets.mk file
+    cat -v >> auto_targets.mk << EOF
+DISTGEN_TARGETS = \\
+$DISTGEN_TARGETS
+EOF
+
+    cat -v >> auto_targets.mk << EOF
+SYMLINK_TARGETS = \\
+$SYMLINK_TARGETS
+EOF

--- a/generate.sh
+++ b/generate.sh
@@ -47,7 +47,31 @@ parse_rules() {
             distgen)
                 [[ -z "$src" ]] && echo "src has to be specified in distgen rule" && exit 1
                 [[ -z "$dest" ]] && echo "dest has to be specified in distgen rule" && exit 1
-                core_subst=$core
+
+                if [[ "$dest" == "Dockerfile"* ]]; then
+                    if [[ "$dest" == "Dockerfile.rhel7" ]]; then
+                        if [[ "$DG_CONF" == *"rhel-7-x86_64.yaml"* ]]; then
+                            conf=rhel-7-x86_64.yaml
+                        else
+                            continue
+                        fi
+                    elif [[ "$dest" == *"Dockerfile.fedora" ]]; then
+                        if [[ "$DG_CONF" == *"fedora-27-x86_64.yaml"* ]]; then
+                            conf=fedora-27-x86_64.yaml
+                        else
+                            continue
+                        fi
+                    elif [[ "$dest" == *"Dockerfile" ]]; then
+                        if [[ "$DG_CONF" == *"centos-7-x86_64.yaml"* ]]; then
+                            conf=centos-7-x86_64.yaml
+                        else
+                            continue
+                        fi
+                    fi
+                else
+                    conf=centos-7-x86_64.yaml
+                fi
+                core_subst=$(echo $core | sed -e "s~__conf__~"${conf}"~g")
                 ;;
             link)
                 [[ -z "$link_name" ]] && echo "link_name has to be specified in link rule" && exit 1
@@ -85,7 +109,7 @@ for version in ${VERSIONS}; do
     # distgen targets
     rules="$DISTGEN_RULES"
     core="${DG} --multispec specs/multispec.yml \\
-	--template \"\$<\" --distro \"$DG_CONF\" \\
+	--template \"\$<\" --distro \"__conf__\" \\
 	--multispec-selector version=\"$version\" --output \"\$@\" ; \\"
     message="Generating \"\$@\" using distgen"
     creator="distgen"


### PR DESCRIPTION
This PR was created as reaction to suggestions in https://github.com/sclorg/postgresql-container/pull/203. It should be an initial effort in using distgen in image repositories.

**Notes:**
- The image repository that uses make distgen should contain:
  - specs/multispec.yml file
  - manifest.sh - lists of files to generate, files to copy (including desired mode) and list of symlinks
 - Results are stored in current directory when not specified in DESTDIR in manifest
  