### PR TITLE
build: Make it possible to add custom repo files at build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,15 @@ function docker_build_with_version {
   if [[ "${UPDATE_BASE}" == "1" ]]; then
     BUILD_OPTIONS+=" --pull=true"
   fi
+  if [ ! -z "$CUSTOM_REPO" ]; then
+    if [ -f "$CUSTOM_REPO" ]; then
+      BUILD_OPTIONS+=" -v $CUSTOM_REPO:/etc/yum.repos.d/sclorg_custom.repo:Z"
+    elif [ -d "$CUSTOM_REPO" ]; then
+      BUILD_OPTIONS+=" -v $CUSTOM_REPO:/etc/yum.repos.d/:Z"
+    else
+      echo "ERROR: file type not known: $CUSTOM_REPO" >&2
+    fi
+  fi
 
   parse_output 'docker build $BUILD_OPTIONS -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"' \
                "awk '/Successfully built/{print \$NF}'" \

--- a/common.mk
+++ b/common.mk
@@ -33,7 +33,8 @@ script_env = \
 	OS=$(OS)                                        \
 	CLEAN_AFTER=$(CLEAN_AFTER)                      \
 	DOCKER_BUILD_CONTEXT=$(DOCKER_BUILD_CONTEXT)    \
-	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
+	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"  \
+	CUSTOM_REPO="$(CUSTOM_REPO)"
 
 # TODO: switch to 'build: build-all' once parallel builds are relatively safe
 .PHONY: build build-serial build-all


### PR DESCRIPTION
This PR adds a new (optional) Makefile argument `CUSTOM_REPO` through which a path to a rpm .repo file (or a directory containing multiple files) can be provided. The content of `CUSTOM_REPO` will then be mounted into `/etc/yum.repos.d/` during build.

Related: #25  