### PR TITLE
add a way to run multiple test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Depends on `tag` as some tests might need to have the images tagged (s2i).
 Similar to `make test` but runs testsuite for Openshift, expected to be found at
 `$gitroot/$version/test/run-openshift`
 
+`make test-with-conu`  
+The rule is similar to `make test`. It runs a test suite written using [conu
+library](https://github.com/user-cont/conu). The path to the test script is
+meant to be at `$gitroot/$version/test/run-conu`. By default the test suite is
+being run in the current environment. You can also run the tests in a container
+by defining variable `CONU_IMAGE`. Container images with conu are available in
+[this docker hub repository](docker.io/usercont/conu:0.6.2), a good value for
+the variable is `docker.io/usercont/conu:0.6.2`.
+
 `make clean`  
 Runs scripts that clean-up the working dir. Depends on the `clean-images` rule by default
 and additional clean rules can be provided through the `clean-hook` variable.

--- a/common.mk
+++ b/common.mk
@@ -87,6 +87,11 @@ test: script_env += TEST_MODE=true
 test: tag
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
+.PHONY: test-with-conu
+test-with-conu: script_env += TEST_CONU_MODE=true
+test-with-conu: tag
+	VERSIONS="$(VERSIONS)" $(script_env) $(test)
+
 .PHONY: test-openshift
 test-openshift: script_env += TEST_OPENSHIFT_MODE=true
 test-openshift: tag

--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,31 @@ for dir in ${VERSIONS}; do
     VERSION=$dir test/run
   fi
 
+  if [ -n "${TEST_CONU_MODE}" ]; then
+    if [[ -x test/run-conu ]]; then
+      if [ -n "${CONU_IMAGE}" ]; then
+        echo "-> Running conu tests in a container"
+        docker run \
+          --net=host \
+          -e VERSION="${dir}" \
+          -e IMAGE_NAME \
+          --rm \
+          --security-opt label=disable \
+          -ti \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v ${PWD}/../:/src \
+          -w "/src/${dir}/" \
+          -ti \
+          "${CONU_IMAGE}" \
+          ./test/run-conu
+      else
+        VERSION="${dir}" ./test/run-conu
+      fi
+    else
+      echo "-> conu tests are not present, skipping"
+    fi
+  fi
+
   if [ -n "${TEST_OPENSHIFT_MODE}" ]; then
     if [[ -x test/run-openshift ]]; then
       VERSION=$dir test/run-openshift


### PR DESCRIPTION
Related: https://github.com/sclorg/s2i-ruby-container/pull/167

Initial version. I'm open to change the workflow & names. Please, advise.

TODO:

 * [x] remove docker invocation
 * [x] add concept of `TEST_SUITES := "test1 test2"` and then `for x in ${TEST_SUITES}; ...`
    * [x] make sure all tests are being run and exit 1 if one of them failed
 * [x] TEST env should support: container, local