### PR TITLE
openshift: pull always the :latest tag

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -578,7 +578,7 @@ ct_os_test_image_update() {
   ct_os_new_project
 
   # Get current image from repository and create an imagestream
-  docker pull "$old_image" 2>/dev/null
+  docker pull "$old_image:latest" 2>/dev/null
   ct_os_upload_image "$old_image" "$istag"
 
   # Setup example application with curent image


### PR DESCRIPTION
We tag each new release of image under :latest, so it's better
to not rely on what _local docker thinks_ is the "latest" tag.

Related to sclorg/postgresql-container/255.