### PR TITLE
Pick oc version by setting PATH

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -316,7 +316,10 @@ function ct_os_cluster_up() {
   local cluster_ip="127.0.0.1"
   [ "${is_public}" == "true" ] && cluster_ip=$(ct_get_public_ip)
 
-  ct_os_set_path_oc "${cluster_version}"
+  if [ -n "${cluster_version}" ] ; then
+    # if $cluster_version is not set, we simply use oc that is available
+    ct_os_set_path_oc "${cluster_version}"
+  fi
 
   mkdir -p ${dir}/{config,data,pv}
   oc cluster up --host-data-dir=${dir}/data --host-config-dir=${dir}/config \
@@ -395,7 +398,7 @@ function ct_os_set_path_oc() {
 function ct_os_get_latest_ver(){
   local vxy="v$1"
   for vz in {3..0} ; do
-    curl -si "https://github.com/openshift/origin/releases/tag/${vxy}.${vz}" | grep -q 'HTTP/1.1 200 OK' && echo "${vxy}.${vz}" && return 0
+    curl -sif "https://github.com/openshift/origin/releases/tag/${vxy}.${vz}" >/dev/null && echo "${vxy}.${vz}" && return 0
   done
   echo "ERROR: version ${vxy} not found in https://github.com/openshift/origin/tags" >&2
   return 1

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -295,7 +295,7 @@ function ct_os_install_in_centos() {
 #                        use "true" for allow remote access to the web-UI,
 #                        "false" is default
 # Arguments: cluster_version - version of the OpenShift cluster to use, empty
-#                              means default version of `oc`; example value: v3.7.0;
+#                              means default version of `oc`; example value: 3.7;
 #                              also can be specified outside by OC_CLUSTER_VERSION
 function ct_os_cluster_up() {
   ct_os_cluster_running && echo "Cluster already running. Nothing is done." && return 0
@@ -316,10 +316,11 @@ function ct_os_cluster_up() {
   local cluster_ip="127.0.0.1"
   [ "${is_public}" == "true" ] && cluster_ip=$(ct_get_public_ip)
 
+  ct_os_set_path_oc "${cluster_version}"
+
   mkdir -p ${dir}/{config,data,pv}
   oc cluster up --host-data-dir=${dir}/data --host-config-dir=${dir}/config \
-                --host-pv-dir=${dir}/pv --use-existing-config --public-hostname=${cluster_ip} \
-                ${cluster_version:+--version=$cluster_version }
+                --host-pv-dir=${dir}/pv --use-existing-config --public-hostname=${cluster_ip}
   oc version
   oc login -u system:admin
   oc project default
@@ -343,6 +344,89 @@ function ct_os_cluster_down() {
 function ct_os_cluster_running() {
   oc cluster status &>/dev/null
 }
+
+# ct_os_set_path_oc OC_VERSION
+# --------------------
+# This is a trick that helps using correct version of the `oc`:
+# The input is version of the openshift in format v3.6.0 etc.
+# If the currently available version of oc is not of this version,
+# it first takes a look into /usr/local/oc-<ver>/bin directory,
+# and if not found there it downloads the community release from github.
+# In the end the PATH variable is changed, so the other tests can still use just 'oc'.
+# Arguments: oc_ver - X.Y part of the version of OSE (e.g. 3.9)
+function ct_os_set_path_oc() {
+  local oc_ver=$(ct_os_get_latest_ver $1)
+  local oc_path
+
+  if oc version | grep -q "oc ${oc_ver%.*}." ; then
+    echo "Binary oc found already available in version ${oc_ver}: `which oc` Doing noting."
+    return 0
+  fi
+
+  # first check whether we already have oc available in /usr/local
+  local installed_oc_path="/usr/local/oc-${oc_ver%.*}/bin"
+
+  if [ -x "${installed_oc_path}/oc" ] ; then
+    oc_path="${installed_oc_path}"
+    echo "Binary oc found in ${installed_oc_path}" >&2
+  else
+    # oc not available in /usr/local, try to download it from github (community release)
+    oc_path="/tmp/oc-${oc_ver}-bin"
+    ct_os_download_upstream_oc "${oc_ver}" "${oc_path}"
+  fi
+  if [ -z "${oc_path}/oc" ] ; then
+    echo "ERROR: oc not found installed, nor downloaded" >&1
+    return 1
+  fi
+  export PATH="${oc_path}:${PATH}"
+  if ! oc version | grep -q "oc ${oc_ver%.*}." ; then
+    echo "ERROR: something went wrong, oc located at ${oc_path}, but oc of version ${oc_ver} not found in PATH ($PATH)" >&1
+    return 1
+  else
+    echo "PATH set correctly, binary oc found in version ${oc_ver}: `which oc`"
+  fi
+}
+
+# ct_os_get_latest_ver VERSION_PART_X
+# --------------------
+# Returns full version (vX.Y.Z) from part of the version (X.Y)
+# Arguments: vxy - X.Y part of the version
+# Returns vX.Y.Z variant of the version
+function ct_os_get_latest_ver(){
+  local vxy="v$1"
+  for vz in {3..0} ; do
+    curl -si "https://github.com/openshift/origin/releases/tag/${vxy}.${vz}" | grep -q 'HTTP/1.1 200 OK' && echo "${vxy}.${vz}" && return 0
+  done
+  echo "ERROR: version ${vxy} not found in https://github.com/openshift/origin/tags" >&2
+  return 1
+}
+
+# ct_os_download_upstream_oc OC_VERSION OUTPUT_DIR
+# --------------------
+# Downloads a particular version of openshift-origin-client-tools from
+# github into specified output directory
+# Arguments: oc_ver - version of OSE (e.g. v3.7.2)
+# Arguments: output_dir - output directory
+function ct_os_download_upstream_oc() {
+  local oc_ver=$1
+  local output_dir=$2
+
+  # check whether we already have the binary in place
+  [ -x "${output_dir}/oc" ] && return 0
+
+  mkdir -p "${output_dir}"
+  # using html output instead of https://api.github.com/repos/openshift/origin/releases/tags/${oc_ver},
+  # because API is limited for number of queries if not authenticated
+  tarball=$(curl -si "https://github.com/openshift/origin/releases/tag/${oc_ver}" | grep -o -e "openshift-origin-client-tools-${oc_ver}-[a-f0-9]*-linux-64bit.tar.gz" | head -n 1)
+
+  # download, unpack the binaries and then put them into output directory
+  echo "Downloading https://github.com/openshift/origin/releases/download/${oc_ver}/${tarball} into ${output_dir}/" >&2
+  curl -sL https://github.com/openshift/origin/releases/download/${oc_ver}/${tarball} | tar -C "${output_dir}" -xz
+  mv -f "${output_dir}/${tarball%.tar.gz}"/* ${output_dir}/
+
+  rmdir "${output_dir}/${tarball%.tar.gz}"
+}
+
 
 # ct_os_test_s2i_app_func IMAGE APP CONTEXT_DIR CHECK_CMD [OC_ARGS]
 # --------------------

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -356,37 +356,37 @@ function ct_os_cluster_running() {
 # it first takes a look into /usr/local/oc-<ver>/bin directory,
 # and if not found there it downloads the community release from github.
 # In the end the PATH variable is changed, so the other tests can still use just 'oc'.
-# Arguments: oc_ver - X.Y part of the version of OSE (e.g. 3.9)
+# Arguments: oc_version - X.Y part of the version of OSE (e.g. 3.9)
 function ct_os_set_path_oc() {
-  local oc_ver=$(ct_os_get_latest_ver $1)
+  local oc_version=$(ct_os_get_latest_ver $1)
   local oc_path
 
-  if oc version | grep -q "oc ${oc_ver%.*}." ; then
-    echo "Binary oc found already available in version ${oc_ver}: `which oc` Doing noting."
+  if oc version | grep -q "oc ${oc_version%.*}." ; then
+    echo "Binary oc found already available in version ${oc_version}: `which oc` Doing noting."
     return 0
   fi
 
   # first check whether we already have oc available in /usr/local
-  local installed_oc_path="/usr/local/oc-${oc_ver%.*}/bin"
+  local installed_oc_path="/usr/local/oc-${oc_version%.*}/bin"
 
   if [ -x "${installed_oc_path}/oc" ] ; then
     oc_path="${installed_oc_path}"
     echo "Binary oc found in ${installed_oc_path}" >&2
   else
     # oc not available in /usr/local, try to download it from github (community release)
-    oc_path="/tmp/oc-${oc_ver}-bin"
-    ct_os_download_upstream_oc "${oc_ver}" "${oc_path}"
+    oc_path="/tmp/oc-${oc_version}-bin"
+    ct_os_download_upstream_oc "${oc_version}" "${oc_path}"
   fi
   if [ -z "${oc_path}/oc" ] ; then
     echo "ERROR: oc not found installed, nor downloaded" >&1
     return 1
   fi
   export PATH="${oc_path}:${PATH}"
-  if ! oc version | grep -q "oc ${oc_ver%.*}." ; then
-    echo "ERROR: something went wrong, oc located at ${oc_path}, but oc of version ${oc_ver} not found in PATH ($PATH)" >&1
+  if ! oc version | grep -q "oc ${oc_version%.*}." ; then
+    echo "ERROR: something went wrong, oc located at ${oc_path}, but oc of version ${oc_version} not found in PATH ($PATH)" >&1
     return 1
   else
-    echo "PATH set correctly, binary oc found in version ${oc_ver}: `which oc`"
+    echo "PATH set correctly, binary oc found in version ${oc_version}: `which oc`"
   fi
 }
 
@@ -408,26 +408,26 @@ function ct_os_get_latest_ver(){
 # --------------------
 # Downloads a particular version of openshift-origin-client-tools from
 # github into specified output directory
-# Arguments: oc_ver - version of OSE (e.g. v3.7.2)
+# Arguments: oc_version - version of OSE (e.g. v3.7.2)
 # Arguments: output_dir - output directory
 function ct_os_download_upstream_oc() {
-  local oc_ver=$1
+  local oc_version=$1
   local output_dir=$2
 
   # check whether we already have the binary in place
   [ -x "${output_dir}/oc" ] && return 0
 
   mkdir -p "${output_dir}"
-  # using html output instead of https://api.github.com/repos/openshift/origin/releases/tags/${oc_ver},
+  # using html output instead of https://api.github.com/repos/openshift/origin/releases/tags/${oc_version},
   # because API is limited for number of queries if not authenticated
-  tarball=$(curl -si "https://github.com/openshift/origin/releases/tag/${oc_ver}" | grep -o -e "openshift-origin-client-tools-${oc_ver}-[a-f0-9]*-linux-64bit.tar.gz" | head -n 1)
+  tarball=$(curl -si "https://github.com/openshift/origin/releases/tag/${oc_version}" | grep -o -e "openshift-origin-client-tools-${oc_version}-[a-f0-9]*-linux-64bit.tar.gz" | head -n 1)
 
   # download, unpack the binaries and then put them into output directory
-  echo "Downloading https://github.com/openshift/origin/releases/download/${oc_ver}/${tarball} into ${output_dir}/" >&2
-  curl -sL https://github.com/openshift/origin/releases/download/${oc_ver}/${tarball} | tar -C "${output_dir}" -xz
-  mv -f "${output_dir}/${tarball%.tar.gz}"/* ${output_dir}/
+  echo "Downloading https://github.com/openshift/origin/releases/download/${oc_version}/${tarball} into ${output_dir}/" >&2
+  curl -sL https://github.com/openshift/origin/releases/download/${oc_version}/"${tarball}" | tar -C "${output_dir}" -xz
+  mv -f "${output_dir}"/"${tarball%.tar.gz}"/* "${output_dir}/"
 
-  rmdir "${output_dir}/${tarball%.tar.gz}"
+  rmdir "${output_dir}"/"${tarball%.tar.gz}"
 }
 
 


### PR DESCRIPTION
Picking version of OpenShift is not enough to be done by setting `--version` argument of `oc`. Ideally, there should be `oc` version of the same version installed. This change first tries to pick `oc` from `/usr/local...` where different preinstalled versions of `oc` may already be prepared. Then, if no suitable `oc` is not found, a community released `oc` binary is downloaded into `/tmp` from https://github.com/openshift/origin/.