### PR TITLE
Add the --all option to remove files from the index

### DIFF
--- a/update-generated.sh
+++ b/update-generated.sh
@@ -35,7 +35,7 @@ git add $VERSIONS
 (
     IFS=$'\n'
     for i in $(git ls-files --deleted) ;do
-        git add "$i"
+        git add --all "$i"
     done
 )
 


### PR DESCRIPTION
Needed for: https://github.com/sclorg/postgresql-container/pull/280

Edit: Some more information:
```
warning: You ran 'git add' with neither '-A (--all)' or '--ignore-removal',
whose behaviour will change in Git 2.0 with respect to paths you removed.
Paths like '9.4/Dockerfile' that are
removed from your working tree are ignored with this version of Git.

* 'git add --ignore-removal <pathspec>', which is the current default,
   ignores paths you removed from your working tree.
* 'git add --all <pathspec>' will let you also record the removals. 
```