### PR TITLE
Allow to run with other than local cluster

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -789,7 +789,7 @@ metadata:
 spec:
   containers:
   - name: command-container
-    image: ${image_name}
+    image: "${image_name}"
     command: ["sleep"]
     args: ["3h"]
   restartPolicy: OnFailure
@@ -798,7 +798,8 @@ EOF
   SECONDS=0
   echo -n "Waiting for command POD ."
   while [ $SECONDS -lt 60 ] ; do
-    ct_os_cmd_image_run "echo 24" &>/dev/null && echo "DONE" && return 0
+    sout="$(ct_os_cmd_image_run 'echo $((11*11))')"
+    grep -q '^121$' <<< "$sout" && echo "DONE" && return 0 || :
     sleep 3
     echo -n "."
   done
@@ -874,7 +875,7 @@ ct_os_test_response_internal() {
 ct_os_get_image_from_pod() {
   local pod_prefix=$1 ; shift
   local pod_name=$(ct_os_get_pod_name $pod_prefix)
-  oc get "po/${pod_name}" -o yaml | grep '^    image: ' | head -n 1 | sed -e 's|^    image: ||'
+  oc get "po/${pod_name}" -o yaml | sed -ne 's/^\s*image:\s*\(.*\)\s*$/\1/ p' | head -1
 }
 
 # ct_os_check_cmd_internal

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -263,9 +263,11 @@ function ct_os_delete_project() {
 # Deletes all objects within the project.
 # Handy when we have one project and want to run more tests.
 function ct_delete_all_objects() {
-  for x in bc builds is dc svc po routes secrets ; do
+  for x in bc builds dc is isimage istag po pv pvc rc routes secrets svc ; do
     oc delete $x --all
   done
+  # for some objects it takes longer to be really deleted, so a dummy sleep
+  # to avoid some races when other test can see not-yet-deleted objects and can fail
   sleep 10
 }
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -307,7 +307,7 @@ function ct_obtain_input() {
 
   local output=$(mktemp "/var/tmp/test-input-XXXXXX$extension")
   if [ -f "${input}" ] ; then
-    cp "${input}" "${output}"
+    cp -f "${input}" "${output}"
   elif [ -d "${input}" ] ; then
     rm -f "${output}"
     cp -r -LH "${input}" "${output}"


### PR DESCRIPTION
Do not run local cluster, if already logged into any (remote/local) cluster -- `oc whoami` should work here, to determine whether we're logged in to the cluster already, but maybe there is a better solution.
Also do not login to a docker registry, if the address (now newly configurable) is defined.