### PR TITLE
Use --base-dir instead of --host-*dir on newer oc tools

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -322,8 +322,19 @@ function ct_os_cluster_up() {
   fi
 
   mkdir -p ${dir}/{config,data,pv}
-  oc cluster up --host-data-dir=${dir}/data --host-config-dir=${dir}/config \
-                --host-pv-dir=${dir}/pv --use-existing-config --public-hostname=${cluster_ip}
+  case $(oc version| head -n 1) in
+    "oc v3.1"*)
+      oc cluster up --base-dir=${dir}/data --public-hostname=${cluster_ip}
+      ;;
+    "oc v3."*)
+      oc cluster up --host-data-dir=${dir}/data --host-config-dir=${dir}/config \
+                    --host-pv-dir=${dir}/pv --use-existing-config --public-hostname=${cluster_ip}
+      ;;
+    *)
+      echo "ERROR: Unexpected oc version." >&2
+      return 1
+      ;;
+  esac
   oc version
   oc login -u system:admin
   oc project default

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -323,12 +323,12 @@ function ct_os_cluster_up() {
 
   mkdir -p ${dir}/{config,data,pv}
   case $(oc version| head -n 1) in
-    "oc v3.1"*)
-      oc cluster up --base-dir=${dir}/data --public-hostname=${cluster_ip}
+    "oc 3.1"?.*)
+      oc cluster up --base-dir="${dir}/data" --public-hostname="${cluster_ip}"
       ;;
     "oc v3."*)
-      oc cluster up --host-data-dir=${dir}/data --host-config-dir=${dir}/config \
-                    --host-pv-dir=${dir}/pv --use-existing-config --public-hostname=${cluster_ip}
+      oc cluster up --host-data-dir="${dir}/data" --host-config-dir="${dir}/config" \
+                    --host-pv-dir="${dir}/pv" --use-existing-config --public-hostname="${cluster_ip}"
       ;;
     *)
       echo "ERROR: Unexpected oc version." >&2


### PR DESCRIPTION
Options `--host-*dir` are missing in `oc` version 3.10 and higher.