### PR TITLE
Tag images into localhost namespace

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -15,10 +15,12 @@ for dir in ${VERSIONS}; do
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
   version=$(docker inspect -f "{{.ContainerConfig.Labels.version}}" $IMAGE_ID)
+  version_tag="localhost/$name:$version"
+  latest_tag="localhost/$name:latest"
 
-  echo "-> Tagging image '$IMAGE_ID' as '$name:$version' and '$name:latest'"
-  docker tag $IMAGE_ID "$name:$version"
-  docker tag $IMAGE_ID "$name:latest"
+  echo "-> Tagging image '$IMAGE_ID' as '$version_tag' and '$latest_tag'"
+  docker tag $IMAGE_ID "$version_tag"
+  docker tag $IMAGE_ID "$latest_tag"
 
   for suffix in squashed raw; do
     id_file=.image-id.$suffix

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ for dir in ${VERSIONS}; do
   pushd ${dir} > /dev/null
   export IMAGE_ID=$(cat .image-id)
   # Kept also IMAGE_NAME as some tests might still use that.
-  export IMAGE_NAME=$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
+  export IMAGE_NAME=localhost/$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
 
   if [ -n "${TEST_MODE}" ]; then
     VERSION=$dir test/run


### PR DESCRIPTION
`podman tag` tags images into `localhost/` namespace by default.
We should do this explicitly so that the `IMAGE_NAME` used is the same
even for docker built images.