### PR TITLE
Do not check version of docker-squash

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Just run `make check`
 Dependencies for testsuite:
 
 - docker
-- docker-squash (version 1.0.5)
+- docker-squash
 - git
 - go-md2man
 - make

--- a/build.sh
+++ b/build.sh
@@ -129,11 +129,7 @@ squash ()
   local base squashed_from squashed= unsquashed=$IMAGE_ID
   test "$SKIP_SQUASH" = 1 && return 0
 
-  # FIXME: We have to use the exact versions here to avoid Docker client
-  #        compatibility issues
-  local squash_version=1.0.5
-  test "$(docker-squash --version 2>&1)" = "$squash_version" || \
-      error "docker-squash $squash_version required"
+  docker-squash --help &>/dev/null || error "docker-squash is required"
 
   if test -f .image-id.squashed; then
       squashed=$(cat .image-id.squashed)


### PR DESCRIPTION
It's responsibility of user to provide working tools to run build+test (mentioned in README).

`docker-squash==1.0.5` is quite old and requires `docker-py` module.
Newer python docker related tools use `docker` module, which
conflicts with `docker-py`. So if some new tool is installed in same
environment (for example `conu` framework) its requirement `docker`
module overwrites `docker-py`.

@pkubatrh @praiskup Please review.