### PR TITLE
build: use docker_squash lib, not docker-squash script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ test: check
 
 check-failures: check-test-lib
 	cd tests/failures/check && make tag && ! make check && make clean
+	cd tests/failures/check && make tag SKIP_SQUASH=0
 
-check: check-failures
+check-squash:
+	./tests/squash/squash.sh
+
+check: check-failures check-squash
 	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh

--- a/squash.py
+++ b/squash.py
@@ -1,0 +1,23 @@
+#! /bin/python
+
+import sys
+import logging
+from platform import python_version
+
+try:
+    from docker_squash import squash
+except ImportError:
+    logging.fatal("please install 'docker_squash' for Python {0}".format(python_version()))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        logging.fatal("%s: %s", sys.argv[0], msg)
+        sys.exit(1)
+
+    print(squash.Squash(
+        log=logging.getLogger(),
+        image=sys.argv[1],
+        from_layer=sys.argv[2]).run()
+    )

--- a/tests/squash/.gitignore
+++ b/tests/squash/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/tests/squash/squash.sh
+++ b/tests/squash/squash.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+set -e
+
+origin=busybox
+squash=$(dirname "$(readlink -f "$0")")/../../squash.py
+cd "$(dirname "$0")"
+
+cat > Dockerfile <<EOF
+FROM $origin
+ENV test=test
+CMD /bin/echo test
+EOF
+out=`docker build . | awk '/Successfully built/{print $NF}'`
+echo "$out"
+squashed=$("${PYTHON-python3}" "$squash" "$out" "$origin")
+output=$(docker run --rm $squashed)
+test "$output" = "test"


### PR DESCRIPTION
The docker-squash script used to print the squashed <image id> on
stderr, but recently it was changed so the image id is printed to
stdout.  To be able to parse image id from both docker_squash
versions (before and after this change), we'd have to have some
ugly if-fork to detect the docker_squash version.

So rather let's do as upstream suggested in [1] and use the
docker_squash library directly.

Also add a simple CI test for the ./squash.py file.

[1] https://github.com/goldmann/docker-squash/pull/145

Fixes: #101