### PR TITLE
Revert "Tag images into localhost namespace"

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -15,12 +15,10 @@ for dir in ${VERSIONS}; do
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
   version=$(docker inspect -f "{{.ContainerConfig.Labels.version}}" $IMAGE_ID)
-  version_tag="localhost/$name:$version"
-  latest_tag="localhost/$name:latest"
 
-  echo "-> Tagging image '$IMAGE_ID' as '$version_tag' and '$latest_tag'"
-  docker tag $IMAGE_ID "$version_tag"
-  docker tag $IMAGE_ID "$latest_tag"
+  echo "-> Tagging image '$IMAGE_ID' as '$name:$version' and '$name:latest'"
+  docker tag $IMAGE_ID "$name:$version"
+  docker tag $IMAGE_ID "$name:latest"
 
   for suffix in squashed raw; do
     id_file=.image-id.$suffix

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ for dir in ${VERSIONS}; do
   pushd ${dir} > /dev/null
   export IMAGE_ID=$(cat .image-id)
   # Kept also IMAGE_NAME as some tests might still use that.
-  export IMAGE_NAME=localhost/$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
+  export IMAGE_NAME=$(docker inspect -f "{{.ContainerConfig.Labels.name}}" $IMAGE_ID)
 
   if [ -n "${TEST_MODE}" ]; then
     VERSION=$dir test/run


### PR DESCRIPTION
Since it seems that this was a bug instead of a feature and was fixed in podman already (v0.10.1) let's revert the "fix" instead of trying to introduce more workarounds for the docker use case.

podman PR: https://github.com/containers/libpod/pull/1551

This reverts commit 7127096e2af5cb37e8f98fd99045b9b6b76f7545.