### PR TITLE
build.sh: correctly use quoted $BUILD_OPTIONS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,7 +108,7 @@ function docker_build_with_version {
     fi
   fi
 
-  parse_output 'docker build $BUILD_OPTIONS -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"' \
+  parse_output 'docker build '"$BUILD_OPTIONS"' -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"' \
                "tail -n 1 | awk '/Successfully built|^--> (Using cache )?[a-fA-F0-9]+$/{print \$NF}'" \
                IMAGE_ID
   clean_image


### PR DESCRIPTION
Previously we built the (centos only?) image label like this:

  "io.openshift.builder-version": "\"7ab45d0\"",

... which was wrong, but it did not hurt Docker.  Now
buildah/podman complaints:

Error: invalid argument
"io.openshift.builder-version=\"7ab45d0\"" for "--label" flag:
parse error on line 1, column 29: bare " in non-quoted-field