### PR TITLE
Make docker build not use the cache

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -539,7 +539,7 @@ EOF
         echo "CMD /usr/libexec/s2i/run" >>"$df_name"
     fi
     # Run the build and tag the result
-    docker build -f "$df_name" -t "$dst_image" .
+    docker build -f "$df_name" --no-cache=true -t "$dst_image" .
     popd
     eval "$oldstate"
 }


### PR DESCRIPTION
Some tests (like the incremental build in the nodejs image) depend on the fact
that a docker image is built from scratch and examines the build log.
With cache, the build log could contain different values than the build run
without the cache.
In case of the nodejs image, the result was that the incremental build
succeeded only every second time when run on the same machine.
Using no cache for docker build should make the tests more stable.