### PR TITLE
test-lib: run ct_s2i_build_as_df code inside a subshell to avoid changing shell options

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -456,17 +456,17 @@ ct_s2i_build_as_df()
     local user_id=
     local df_name=
     local tmpdir=
-    local oldstate=
     local incremental=false
 
-    oldstate=$(set +o)
+    # Run the entire thing inside a subshell so that we do not leak shell options outside of the function
+    (
     # Error out if any part of the build fails
     set -e
 
     # Use /tmp to not pollute cwd
     tmpdir=$(mktemp -d)
     df_name=$(mktemp -p "$tmpdir" Dockerfile.XXXX)
-    pushd "$tmpdir"
+    cd "$tmpdir"
     # Check if the image is available locally and try to pull it if it is not
     docker images "$src_image" &>/dev/null || echo "$s2i_args" | grep -q "pull-policy=never" || docker pull "$src_image"
     user=$(docker inspect -f "{{.Config.User}}" "$src_image")
@@ -540,8 +540,7 @@ EOF
     fi
     # Run the build and tag the result
     docker build -f "$df_name" --no-cache=true -t "$dst_image" .
-    popd
-    eval "$oldstate"
+    )
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
The previous version with 'oldstate=$(set +o)' followed by 'eval "$oldstate"' seems
to have been setting "+e" to the caller of the function.