### PR TITLE
Add internal Red Hat Nexus proxy server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,16 @@ all:
 
 TESTED_IMAGES = \
 	postgresql-container \
-	s2i-python-container
+	s2i-python-container \
+	s2i-nodejs-container
 
 .PHONY: check test all check-failures
 
 
 TEST_LIB_TESTS = \
 	path_foreach \
-	random_string
+	random_string \
+	test_npm
 
 $(TEST_LIB_TESTS):
 	@echo "  RUN TEST '$@'" ; \

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -208,6 +208,40 @@ function ct_doc_content_old() {
 }
 
 
+# ct_mount_ca_file
+# ------------------
+# Check if /etc/pki/certs/RH-IT-Root-CA.crt file exists
+# return mount string for containers
+ct_mount_ca_file()
+{
+    local mount_parameter=""
+    if [ -n $NPM_REGISTRY ]; then
+        local ca_full_path="/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt"
+        if [ -f "$ca_full_path" ]; then
+            mount_parameter="-v $ca_full_path:$ca_full_path:ro,Z"
+        fi
+    fi
+    echo "$mount_parameter"
+}
+
+# ct_build_s2i_npm_variables URL_TO_NPM_JS_SERVER
+# ------------------------------
+# Function returns -e NPM_MIRROR and -v MOUNT_POINT_FOR_CAFILE
+function ct_build_s2i_npm_variables() {
+    local ca_full_path="/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt"
+    if [ ! -z $NPM_REGISTRY ]; then
+        # Check if CA file exists and update CA authorities in image.
+        if [ -f "$ca_full_path" ]; then
+          mount_option=$(ct_mount_ca_file)
+          echo "-e NPM_MIRROR=$NPM_REGISTRY $mount_option"
+        else
+          echo ""
+        fi
+    else
+        echo ""
+    fi
+}
+
 # ct_npm_works
 # --------------------
 # Checks existance of the npm tool and runs it.
@@ -221,7 +255,8 @@ function ct_npm_works() {
     return 1
   fi
 
-  docker run --rm ${IMAGE_NAME} /bin/bash -c "npm install jquery && test -f node_modules/jquery/src/jquery.js"
+  docker run $(ct_mount_ca_file) --rm ${IMAGE_NAME} /bin/bash -c "npm install jquery && test -f node_modules/jquery/src/jquery.js"
+
   if [ $? -ne 0 ] ; then
     echo "ERROR: npm could not install jquery inside the image ${IMAGE_NAME}." >&2
     return 1
@@ -229,7 +264,6 @@ function ct_npm_works() {
 
   : "  Success!"
 }
-
 
 # ct_path_append PATH_VARNAME DIRECTORY
 # -------------------------------------
@@ -457,6 +491,7 @@ ct_s2i_build_as_df()
     local df_name=
     local tmpdir=
     local incremental=false
+    local ca_file=false
 
     # Run the entire thing inside a subshell so that we do not leak shell options outside of the function
     (
@@ -518,6 +553,11 @@ EOF
     fi
     # Filter out env var definitions from $s2i_args and create Dockerfile ENV commands out of them
     echo "$s2i_args" | grep -o -e '\(-e\|--env\)[[:space:]=]\S*=\S*' | sed -e 's/-e /ENV /' -e 's/--env[ =]/ENV /' >>"$df_name"
+    # Check if CA autority is present on host and add it into Dockerfile
+    if [ -f "/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt" ]; then
+      echo "RUN cd /etc/pki/ca-trust/source/anchors && update-ca-trust extract" >>"$df_name"
+      ca_file=true
+    fi
     # Add in artifacts if doing an incremental build
     if $incremental; then
         echo "RUN mkdir /tmp/artifacts" >>"$df_name"
@@ -538,8 +578,14 @@ EOF
     else
         echo "CMD /usr/libexec/s2i/run" >>"$df_name"
     fi
+    if $ca_file; then
+        # Check if -v parameter is present in s2i_args and add it into docker build command
+        mount_ca_option=$(echo "$s2i_args" | grep -o -e '\(-v\)[[:space:]]\.*\S*')
+    else
+        mount_ca_option=""
+    fi
     # Run the build and tag the result
-    docker build -f "$df_name" --no-cache=true -t "$dst_image" .
+    docker build $mount_ca_option -f "$df_name" --no-cache=true -t "$dst_image" .
     )
 }
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -580,7 +580,7 @@ EOF
 
     if $ca_file; then
         # Check if -v parameter is present in s2i_args and add it into docker build command
-        mount_options=$(echo "$s2i_args" | grep -o -e '\(-v\)[[:space:]]\.*\S*')
+        mount_options=$(echo "$s2i_args" | grep -o -e '\(-v\)[[:space:]]\.*\S*' || true)
     fi
 
     # Run the build and tag the result

--- a/tests/test-lib/test_npm
+++ b/tests/test-lib/test_npm
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+set -ex
+
+. test-lib.sh
+
+NPM_REGISTRY=""
+output=$(ct_build_s2i_npm_variables)
+test x"$output" == "x"
+
+ca_file="/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt"
+NPM_REGISTRY="https://foobar.registry.org"
+if [ -f "$ca_file" ]; then
+    output=$(ct_build_s2i_npm_variables)
+    test x"$output" == "x-e NPM_MIRROR=$NPM_REGISTRY -v $ca_file:$ca_file:ro,Z"
+fi


### PR DESCRIPTION
This pull request adds to the `test-lib.sh` file internal Red Hat Nexus proxy server to `ct_npm_works` function.
We do not want to connect `npmjs` registry directly, based on the request from npmjs.

Also, s2i-nodejs-container is added to `Makefile` in order to check that `ct_npm_works` properly with the internal Red Hat Nexus proxy server.
This is used ONLY for testing containers.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>