### PR TITLE
Add shellcheck script and fix many shell issues found by shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: shell
+os: linux
+script:
+  - make shellcheck

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ check-test-lib: $(TEST_LIB_TESTS)
 
 test: check
 
+shellcheck:
+	./run-shellcheck.sh `git ls-files *.sh`
+
 check-failures: check-test-lib
 	cd tests/failures/check && make tag && ! make check && make clean
 	grep -q "Red Hat Enterprise Linux release 8" /etc/system-release || cd tests/failures/check && make tag SKIP_SQUASH=0

--- a/clean.sh
+++ b/clean.sh
@@ -7,10 +7,12 @@ for version
 do
     remove_images=
     for idfile in .image-id.raw .image-id.squashed; do
+        # shellcheck disable=SC2039
         test ! -f "$version/$idfile" || remove_images+=" $(cat "$version/$idfile")"
     done
 
     for image in $remove_images; do
+        # shellcheck disable=SC2046
         docker rm -f $(docker ps -q -a -f "ancestor=$image") 2>/dev/null || :
         docker rmi -f "$image" || :
     done

--- a/common.mk
+++ b/common.mk
@@ -12,6 +12,7 @@ endif
 build = $(SHELL) $(common_dir)/build.sh
 test =  $(SHELL) $(common_dir)/test.sh
 testr = $(SHELL) $(common_dir)/test-remote-cluster.sh
+shellcheck =  $(SHELL) $(common_dir)/run-shellcheck.sh
 tag =   $(SHELL) $(common_dir)/tag.sh
 clean = $(SHELL) $(common_dir)/clean.sh
 
@@ -51,6 +52,7 @@ endif
 
 SKIP_SQUASH ?= 1
 DOCKER_BUILD_CONTEXT ?= .
+SHELLCHECK_FILES ?= .
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
@@ -101,6 +103,10 @@ test-openshift-remote-cluster:
 test-openshift: script_env += TEST_OPENSHIFT_MODE=true
 test-openshift: tag
 	VERSIONS="$(VERSIONS)" BASE_IMAGE_NAME="$(BASE_IMAGE_NAME)" $(script_env) $(test)
+
+.PHONY: shellcheck
+shellcheck:
+	$(shellcheck) $(SHELLCHECK_FILES)
 
 .PHONY: tag
 tag: build

--- a/generate.sh
+++ b/generate.sh
@@ -14,6 +14,7 @@
 # Supported type rules are now COPY_RULES, DISTGEN_RULES and SYMLINKS_RULES
 # for real example see https://github.com/sclorg/postgresql-container/blob/master/manifest.sh
 
+# shellcheck disable=SC1090
 source "$MANIFEST_FILE"
 
 die () { echo "FATAL: $*" ; exit 1 ; }
@@ -42,12 +43,13 @@ parse_rules() {
     OLD_IFS=$IFS
     IFS=";"
     for rule in $rules; do
-        if [ -z $(echo "$rule"| tr -d '[:space:]') ]; then
+        if [ -z "$(echo "$rule"| tr -d '[:space:]')" ]; then
             continue
         fi
         clean_rule_variables
-        eval $rule
+        eval "$rule"
 
+        # shellcheck disable=SC2016
         cdir='$(CDIR)'
         case "$creator" in
             copy)
@@ -90,7 +92,8 @@ parse_rules() {
                 [[ -z "$link_name" ]] && echo "link_name has to be specified in link rule" && exit 1
                 [[ -z "$link_target" ]] && echo "link_target has to be specified in link rule" && exit 1
                 dest="$link_name"
-                core_subst=$(echo $core | sed -e "s~__link_target__~"${link_target}"~g")
+                # shellcheck disable=SC2001
+                core_subst=$(echo "$core" | sed -e "s~__link_target__~${link_target}~g")
                 prolog="\$(V_LN)$cdir"
                 ;;
         esac

--- a/run-shellcheck.sh
+++ b/run-shellcheck.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+VERBOSE_OUTPUT=0
+
+usage() {
+  echo "Usage: $(basename "$0") [ -v|--verbose ]  <dir|file> [ <dir|file> ... ]"
+}
+
+verbose() {
+  if [ "${VERBOSE_OUTPUT}" -eq 1 ] ; then
+	  echo "$@" >&2
+	fi
+}
+
+if [ $# -eq 0 ] ; then
+  echo "ERROR: No arguments given."
+  usage
+  exit 1
+fi
+
+case $1 in
+	-v|--verbose) VERBOSE_OUTPUT=1; shift ;;
+esac
+
+filter_files() {
+  while read -r file ; do
+    if [ -L "$file" ] ; then
+			verbose "Ignoring symlink $file."
+			continue
+    fi
+    verbose "Will scan $file"
+		echo "$file"
+  done
+}
+
+detect_shell_files() {
+  find -H "$@" -type f -not -path '*/\.git/*' -exec grep -l '^#!/bin/\(bash\|sh\)' {} +
+  find -H "$@" -name '*.sh' -not -path '*/\.git/*'
+}
+
+# Run shellcheck on all files (we should also ignore symlinks)
+detect_shell_files "$@" | filter_files | sort -u | xargs shellcheck
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/tag.sh
+++ b/tag.sh
@@ -11,17 +11,17 @@ set -e
 
 for dir in ${VERSIONS}; do
   [ ! -e "${dir}/.image-id" ] && echo "-> Image for version $dir not built, skipping tag." && continue
-  pushd ${dir} > /dev/null
+  pushd "${dir}" > /dev/null
   IMAGE_ID=$(cat .image-id)
-  name=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
-  version=$(docker inspect -f "{{.Config.Labels.version}}" $IMAGE_ID)
+  name=$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID")
+  version=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
   commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
   date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
 
   echo "-> Tagging image '$IMAGE_ID' as '$name:$version' and '$name:latest' and '$name:$date_and_hash'"
-  docker tag $IMAGE_ID "$name:$version"
-  docker tag $IMAGE_ID "$name:latest"
-  docker tag $IMAGE_ID "$name:$date_and_hash"
+  docker tag "$IMAGE_ID" "$name:$version"
+  docker tag "$IMAGE_ID" "$name:latest"
+  docker tag "$IMAGE_ID" "$name:$date_and_hash"
 
   for suffix in squashed raw; do
     id_file=.image-id.$suffix

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -753,7 +753,9 @@ function ct_os_test_template_app_func() {
   # considered an internal template name, like 'mysql', so use the name
   # explicitly
   local local_template
-  local namespace=${CT_NAMESPACE:-$(oc project -q)}
+  local namespace
+  
+  namespace=${CT_NAMESPACE:-$(oc project -q)}
 
   local_template=$(ct_obtain_input "${template}" 2>/dev/null || echo "--template=${template}")
   # shellcheck disable=SC2086

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -261,12 +261,12 @@ function ct_npm_works() {
   fi
 
   # shellcheck disable=SC2046
-  docker run -d $(ct_mount_ca_file) --rm --cidfile="$cid_file" ${IMAGE_NAME}-testapp
+  docker run -d $(ct_mount_ca_file) --rm --cidfile="$cid_file" "${IMAGE_NAME}-testapp"
 
   # Wait for the container to write it's CID file
   ct_wait_for_cid "$cid_file" || return 1
 
-  if ! docker exec $(cat "$cid_file") /bin/bash -c "npm --verbose install jquery && test -f node_modules/jquery/src/jquery.js" >${tmpdir}/jquery 2>&1 ; then
+  if ! docker exec "$(cat "$cid_file")" /bin/bash -c "npm --verbose install jquery && test -f node_modules/jquery/src/jquery.js" >"${tmpdir}/jquery" 2>&1 ; then
     echo "ERROR: npm could not install jquery inside the image ${IMAGE_NAME}." >&2
     return 1
   fi
@@ -279,7 +279,7 @@ function ct_npm_works() {
   fi
 
   if [ -f "$cid_file" ]; then
-      docker stop $(cat "$cid_file")
+      docker stop "$(cat "$cid_file")"
       rm "$cid_file"
   fi
   : "  Success!"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -266,9 +266,7 @@ function ct_npm_works() {
   # Wait for the container to write it's CID file
   ct_wait_for_cid "$cid_file" || return 1
 
-  docker exec $(cat "$cid_file") /bin/bash -c "npm --verbose install jquery && test -f node_modules/jquery/src/jquery.js" >${tmpdir}/jquery 2>&1
-
-  if [ $? -ne 0 ] ; then
+  if ! docker exec $(cat "$cid_file") /bin/bash -c "npm --verbose install jquery && test -f node_modules/jquery/src/jquery.js" >${tmpdir}/jquery 2>&1 ; then
     echo "ERROR: npm could not install jquery inside the image ${IMAGE_NAME}." >&2
     return 1
   fi

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # Test a container image.
 #
@@ -24,20 +25,21 @@ EXPECTED_EXIT_CODE=0
 # Uses: $CID_FILE_DIR - path to directory containing cid_files
 # Uses: $EXPECTED_EXIT_CODE - expected container exit code
 function ct_cleanup() {
-  for cid_file in $CID_FILE_DIR/* ; do
-    local container=$(cat $cid_file)
+  for cid_file in "$CID_FILE_DIR"/* ; do
+    local container
+    container=$(cat "$cid_file")
 
     : "Stopping and removing container $container..."
-    docker stop $container
-    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $container)
+    docker stop "$container"
+    exit_status=$(docker inspect -f '{{.State.ExitCode}}' "$container")
     if [ "$exit_status" != "$EXPECTED_EXIT_CODE" ]; then
       : "Dumping logs for $container"
-      docker logs $container
+      docker logs "$container"
     fi
-    docker rm -v $container
-    rm $cid_file
+    docker rm -v "$container"
+    rm "$cid_file"
   done
-  rmdir $CID_FILE_DIR
+  rmdir "$CID_FILE_DIR"
   : "Done."
 }
 
@@ -55,7 +57,7 @@ function ct_enable_cleanup() {
 # Uses: $CID_FILE_DIR - path to directory containing cid_files
 function ct_get_cid() {
   local name="$1" ; shift || return 1
-  echo $(cat "$CID_FILE_DIR/$name")
+  cat "$CID_FILE_DIR/$name"
 }
 
 # ct_get_cip [id]
@@ -64,7 +66,7 @@ function ct_get_cid() {
 # Argument: id - container id
 function ct_get_cip() {
   local id="$1" ; shift
-  docker inspect --format='{{.NetworkSettings.IPAddress}}' $(ct_get_cid "$id")
+  docker inspect --format='{{.NetworkSettings.IPAddress}}' "$(ct_get_cid "$id")"
 }
 
 # ct_wait_for_cid [cid_file]
@@ -79,9 +81,9 @@ function ct_wait_for_cid() {
   local attempt=1
   local result=1
   while [ $attempt -le $max_attempts ]; do
-    [ -f $cid_file ] && [ -s $cid_file ] && return 0
+    [ -f "$cid_file" ] && [ -s "$cid_file" ] && return 0
     : "Waiting for container start..."
-    attempt=$(( $attempt + 1 ))
+    attempt=$(( attempt + 1 ))
     sleep $sleep_time
   done
   return 1

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -325,7 +325,7 @@ function ct_run_test_list() {
   for test_case in $TEST_LIST; do
     : "Running test $test_case"
     # shellcheck source=/dev/null
-    [ -f test/"$test_case" ] && source test/"$test_case"
+    [ -f "test/$test_case" ] && source "test/$test_case"
     # shellcheck source=/dev/null
     [ -f ../test/"$test_case" ] && source ../test/"$test_case"
     $test_case

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -327,7 +327,7 @@ function ct_run_test_list() {
     # shellcheck source=/dev/null
     [ -f "test/$test_case" ] && source "test/$test_case"
     # shellcheck source=/dev/null
-    [ -f ../test/"$test_case" ] && source ../test/"$test_case"
+    [ -f "../test/$test_case" ] && source "../test/$test_case"
     $test_case
   done;
 }

--- a/test-remote-cluster.sh
+++ b/test-remote-cluster.sh
@@ -21,7 +21,7 @@ export NAMESPACE
 export REGISTRY
 
 for dir in ${VERSIONS}; do
-  pushd ${dir} > /dev/null
+  pushd "${dir}" > /dev/null
 
   export IMAGE_NAME="${REGISTRY}${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 

--- a/test.sh
+++ b/test.sh
@@ -10,10 +10,12 @@ set -e
 
 for dir in ${VERSIONS}; do
   [ ! -e "${dir}/.image-id" ] && echo "-> Image for version $dir not built, skipping tests." && continue
-  pushd ${dir} > /dev/null
-  export IMAGE_ID=$(cat .image-id)
+  pushd "${dir}" > /dev/null
+  IMAGE_ID=$(cat .image-id)
+  export IMAGE_ID
   # Kept also IMAGE_NAME as some tests might still use that.
-  export IMAGE_NAME=$(docker inspect -f "{{.Config.Labels.name}}" $IMAGE_ID)
+  IMAGE_NAME=$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID")
+  export IMAGE_NAME
 
   if [ -n "${TEST_MODE}" ]; then
     VERSION=$dir test/run

--- a/update-generated.sh
+++ b/update-generated.sh
@@ -54,6 +54,7 @@ done
 # source directory is not needed anymore
 rm -rf "$srcdir"
 
+# shellcheck disable=SC2086
 git add $versions
 
 # Add deleted files to the index as well


### PR DESCRIPTION
This adds a new make command `make shellcheck` that is supposed to be run by CI (travis-ci might be used). It only checks the scripts *.sh so far (no tests/*) and the idea is to do similarly over time in other containers, to avoid issues coming from poor shell scripting.

The idea is to specify `SHELLCHECK_FILES` in the `Makefile` for each image to scan only files we want. By default it scans the whole repository, which might be too much.