### PR TITLE
Remove ro option from mount_parameter

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -222,7 +222,7 @@ function ct_mount_ca_file()
   # mount CA file only if NPM_REGISTRY variable is present.
   local mount_parameter=""
   if [ -n "$NPM_REGISTRY" ] && [ -f "$(full_ca_file_path)" ]; then
-    mount_parameter="-v $(full_ca_file_path):$(full_ca_file_path):ro,Z"
+    mount_parameter="-v $(full_ca_file_path):$(full_ca_file_path):Z"
   fi
   echo "$mount_parameter"
 }

--- a/tests/test-lib/test_npm
+++ b/tests/test-lib/test_npm
@@ -12,5 +12,5 @@ ca_file="/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt"
 NPM_REGISTRY="https://foobar.registry.org"
 if [ -f "$ca_file" ]; then
     output=$(ct_build_s2i_npm_variables)
-    test x"$output" == "x-e NPM_MIRROR=$NPM_REGISTRY -v $ca_file:$ca_file:ro,Z"
+    test x"$output" == "x-e NPM_MIRROR=$NPM_REGISTRY -v $ca_file:$ca_file:Z"
 fi


### PR DESCRIPTION
We need to remove `ro` parameter from mount command.
It fails on RHEL-8

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>