### PR TITLE
Use local var for cidfile

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -254,7 +254,7 @@ function ct_npm_works() {
   local tmpdir
   tmpdir=$(mktemp -d)
   : "  Testing npm in the container image"
-  cid_file="${tmpdir}/cid"
+  local cid_file="${tmpdir}/cid"
   if ! docker run --rm "${IMAGE_NAME}" /bin/bash -c "npm --version" >"${tmpdir}/version" ; then
     echo "ERROR: 'npm --version' does not work inside the image ${IMAGE_NAME}." >&2
     return 1


### PR DESCRIPTION
So that we do not replace some value that is still in-use in caller
Required-by: s2i-ruby-container#248