### PR TITLE
Add make target for testing SCL container in OpenShift 4 environment

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -95,7 +95,8 @@ test-with-conu: script_env += TEST_CONU_MODE=true
 test-with-conu: tag
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
-.PHONY: test-openshift-remote-cluster
+.PHONY: test-openshift-4
+test-openshift-remote-cluster: script_env += TEST_OPENSHIFT_4=true
 test-openshift-remote-cluster:
 	VERSIONS="$(VERSIONS)" BASE_IMAGE_NAME="$(BASE_IMAGE_NAME)" $(script_env) $(testr)
 

--- a/test.sh
+++ b/test.sh
@@ -46,6 +46,14 @@ for dir in ${VERSIONS}; do
     fi
   fi
 
+  if [ -n "${TEST_OPENSHIFT_4}" ]; then
+    if [[ -x test/run-openshift-remote-cluster ]]; then
+        VERSION=$dir test/run-openshift-remote-cluster
+    else
+      echo "-> Tests for OpenShift 4 are not present. Add run-openshift-remote-cluster script, skipping"
+    fi
+  fi
+
   if [ -n "${TEST_OPENSHIFT_MODE}" ]; then
     if [[ -x test/run-openshift ]]; then
       VERSION=$dir test/run-openshift


### PR DESCRIPTION
This commit adds support testing SCL containers
in OpenShift 4 environment.

Tests are executed on remote cluster, so each image
which is going to be tested in OCP4 has to have
`test-openshift-remote-cluster` script in test directory.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>