### PR TITLE
Fixes makefile target test-openshift-4 is missing.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -96,8 +96,8 @@ test-with-conu: tag
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
 .PHONY: test-openshift-4
-test-openshift-remote-cluster: script_env += TEST_OPENSHIFT_4=true
-test-openshift-remote-cluster:
+test-openshift-4: script_env += TEST_OPENSHIFT_4=true
+test-openshift-4:
 	VERSIONS="$(VERSIONS)" BASE_IMAGE_NAME="$(BASE_IMAGE_NAME)" $(script_env) $(testr)
 
 .PHONY: test-openshift

--- a/test-remote-cluster.sh
+++ b/test-remote-cluster.sh
@@ -25,7 +25,11 @@ for dir in ${VERSIONS}; do
 
   export IMAGE_NAME="${REGISTRY}${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
-  VERSION=$dir test/run-openshift-remote-cluster
+  if [[ -x test/run-openshift-remote-cluster ]]; then
+    VERSION=$dir test/run-openshift-remote-cluster
+  else
+    echo "-> Tests for OpenShift 4 are not present. Add run-openshift-remote-cluster script, skipping"
+  fi
 
   popd > /dev/null
 done


### PR DESCRIPTION
make test-openshift-4 response with message
+ make test-openshift-4 TARGET=rhel7 UPDATE_BASE=1 TAG_ON_SUCCESS=true
make: Nothing to be done for `test-openshift-4'

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>