### PR TITLE
Add a function to test an image stream

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1060,4 +1060,27 @@ function ct_os_check_cmd_internal() {
   return 1
 }
 
+# ct_os_test_image_stream
+# ------------------------
+# Creates an image stream and deploys a specified template. Then checks that a pod runs.
+# Argument: image_stream_file - local file name with an image stream
+# Argument: template_file - local file name with a template
+# Argument: service_name - how the pod will be named (prefix)
+function ct_os_test_image_stream() {
+  local image_stream_file=$1
+  local template_file=$2
+  local service_name=$3
+
+  echo "Running image stream test for stream $image_stream_file and template $template_file"
+  # shellcheck disable=SC2119
+  ct_os_new_project
+
+  oc create -f "${image_stream_file}"
+  oc process -p NAMESPACE=$(oc project -q) -f "${template_file}" | oc create -f -
+  ct_os_wait_pod_ready "${service_name}" 120
+
+  # shellcheck disable=SC2119
+  ct_os_delete_project
+}
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1074,7 +1074,7 @@ function ct_os_test_image_stream() {
   local template_params=${4:-}
 
   if [ $# -lt 3 ] || [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ]; then
-    echo "ERROR: ct_os_test_image_stream() requires at least 3 arguments that cannot be emtpy." >&2
+    echo "ERROR: ct_os_test_image_stream() requires at least 3 arguments that cannot be empty." >&2
     return 1
   fi
 

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1066,17 +1066,20 @@ function ct_os_check_cmd_internal() {
 # Argument: image_stream_file - local file name with an image stream
 # Argument: template_file - local file name with a template
 # Argument: service_name - how the pod will be named (prefix)
+# Argument: template_params (optional) - parameters for the template, like image stream version
 function ct_os_test_image_stream() {
   local image_stream_file=$1
   local template_file=$2
   local service_name=$3
+  local template_params=${4:-}
 
   echo "Running image stream test for stream $image_stream_file and template $template_file"
   # shellcheck disable=SC2119
   ct_os_new_project
 
   oc create -f "${image_stream_file}"
-  oc process -p NAMESPACE=$(oc project -q) -f "${template_file}" | oc create -f -
+  # shellcheck disable=SC2086
+  oc process -p NAMESPACE=$(oc project -q) ${template_params} -f "${template_file}" | oc create -f -
   ct_os_wait_pod_ready "${service_name}" 120
 
   # shellcheck disable=SC2119

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1079,7 +1079,7 @@ function ct_os_test_image_stream() {
 
   oc create -f "${image_stream_file}"
   # shellcheck disable=SC2086
-  oc process -p NAMESPACE=$(oc project -q) ${template_params} -f "${template_file}" | oc create -f -
+  oc process -p NAMESPACE="$(oc project -q)" ${template_params} -f "${template_file}" | oc create -f -
   ct_os_wait_pod_ready "${service_name}" 120
 
   # shellcheck disable=SC2119


### PR DESCRIPTION
An example of the usage:
```
ct_os_test_image_stream \
    "imagestreams/postgresql-rhel7.json" \
    "examples/postgresql-ephemeral-template.json" \
    postgresql \
    "-p POSTGRESQL_VERSION=${VERSION}"
```