### PR TITLE
Add a function to test the latest version in an image stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ check-squash:
 	./tests/squash/squash.sh
 
 check-latest-imagestream:
-	cp check_imagestreams.py tests/ && cd tests && ./check_imagestreams.sh
+	cd tests && ./check_imagestreams.sh
 
 check: check-failures check-squash check-latest-imagestream
 	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ check-failures: check-test-lib
 check-squash:
 	./tests/squash/squash.sh
 
-check: check-failures check-squash
+check-latest-imagestream:
+	cp check_imagestreams.py tests/ && cd tests && ./check_imagestreams.sh
+
+check: check-failures check-squash check-latest-imagestream
 	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh

--- a/check_imagestreams.py
+++ b/check_imagestreams.py
@@ -1,0 +1,63 @@
+#! /bin/python
+
+import os
+import sys
+import json
+import logging
+
+from pathlib import Path
+from typing import Dict
+
+IMAGESTREAMS_DIR: str = "imagestreams"
+
+
+class ImageStreamChecker(object):
+    version: str = ""
+    results: Dict = {}
+
+    def __init__(self, version: str):
+        self.version = version
+
+    def load_json_file(self, filename: Path):
+        with open(str(filename)) as f:
+            return json.load(f)
+
+    def check_version(self, json_dict: Dict):
+        return [tags for tags in json_dict["spec"]["tags"] if tags["name"] == self.version]
+
+    def check_latest_tag(self, json_dict: Dict):
+        latest_tag_correct: bool = False
+        for tags in json_dict["spec"]["tags"]:
+            if tags["name"] != "latest":
+                continue
+            if tags["from"]["name"] == self.version:
+                latest_tag_correct = True
+        return latest_tag_correct
+
+    def check_imagestreams(self):
+        p = Path(".")
+        json_files = p.glob(f"{IMAGESTREAMS_DIR}/*.json")
+        if not json_files:
+            print(f"No json files present in {IMAGESTREAMS_DIR}.")
+            return 0
+        for f in json_files:
+            print(f"Checking file {str(f)}.")
+            json_dict = self.load_json_file(f)
+            if not (self.check_version(json_dict) and self.check_latest_tag(json_dict)):
+                print(f"The latest version is not present in {str(f)} or in latest tag.")
+                self.results[f] = False
+        if self.results:
+            return 1
+        print("Imagestreams contains the latest version.")
+        return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        logging.fatal("%s: %s", sys.argv[0], "VERSION as an argument was not provided")
+        sys.exit(1)
+
+    print(f"Version to check is {sys.argv[1]}.")
+    isc = ImageStreamChecker(version=sys.argv[1])
+    sys.exit(isc.check_imagestreams())
+

--- a/check_imagestreams.py
+++ b/check_imagestreams.py
@@ -1,6 +1,5 @@
-#! /bin/python
+#!/bin/env python3
 
-import os
 import sys
 import json
 import logging

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -780,9 +780,11 @@ ct_check_image_availability() {
 # Also the latest tag in the imagestreams has to contain the latest version
 ct_check_latest_imagestreams() {
     local latest_version=
+    local test_lib_dir=
 
     latest_version=$(grep 'VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
-    python3 ./common/check_imagestreams.py "$latest_version"
+    test_lib_dir=$(dirname "$(readlink -f "$0")")
+    python3 "${test_lib_dir}/check_imagestreams.py" "$latest_version"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -773,4 +773,10 @@ ct_check_image_availability() {
   fi
 }
 
+ct_check_latest_imagestreams() {
+    local latest_version=
+
+    latest_version=$(grep 'VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
+    python3 ./common/check_imagestreams.py "$latest_version"
+}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -773,10 +773,16 @@ ct_check_image_availability() {
   fi
 }
 
+# ct_check_latest_imagestreams
+# -----------------------------
+# Check if the latest version present in Makefile in the variable VERSIONS
+# is present in all imagestreams.
+# Also the latest tag in the imagestreams has to contain the latest version
 ct_check_latest_imagestreams() {
     local latest_version=
 
     latest_version=$(grep 'VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
     python3 ./common/check_imagestreams.py "$latest_version"
 }
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 .image-id*
 help.1
+check_imagestreams.py

--- a/tests/check_imagestreams.sh
+++ b/tests/check_imagestreams.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -x
+
+check_imagestreams=$(dirname "$(readlink -f "$0")")/../check_imagestreams.py
+"${PYTHON-python3}" "$check_imagestreams" "2.5"
+test $? -eq 1
+"${PYTHON-python3}" "$check_imagestreams" "2.4"
+test $? -eq 0

--- a/tests/imagestreams/testing_file.json
+++ b/tests/imagestreams/testing_file.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "v1",
+  "kind": "ImageStream",
+  "metadata": {
+    "annotations": {
+      "openshift.io/display-name": "Apache HTTP Server (httpd)"
+    },
+    "name": "httpd"
+  },
+  "spec": {
+    "tags": [
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "2.4"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/httpd-24-rhel7"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The commit contains these changes:
* test for check latest image stream
* python file which checks the latest version against image
stream tags
* function `ct_check_latest_imagestreams`

Required-by: s2i-nodejs-container#241

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>