### PR TITLE
Refactor OpenShift tests to work also with remote OCP4

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -623,7 +623,12 @@ function ct_os_test_s2i_app_func() {
     echo "Importing image ${image_name} as ${namespace}/${image_tagged}"
     # Use --reference-policy=local to pull remote image content to the cluster
     # Works around the issue of builder pods not having access to registry.redhat.io
-    oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local
+    SECONDS=0
+    while ! oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local ; do
+      [ "$SECONDS" -gt 20 ] && echo "oc tag ${image_name} ${namespace}/${image_tagged} did not work several times." && return 1
+      sleep 3
+      echo "oc tag ${image_name} ${namespace}/${image_tagged} did not work, trying again"
+    done
   else
     echo "Uploading image ${image_name} as ${image_tagged}"
     ct_os_upload_image "${image_name}" "${image_tagged}"
@@ -760,7 +765,12 @@ function ct_os_test_template_app_func() {
     echo "Importing image ${image_name} as ${image_tagged}"
     # Use --reference-policy=local to pull remote image content to the cluster
     # Works around the issue of builder pods not having access to registry.redhat.io
-    oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local
+    SECONDS=0
+    while ! oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local ; do
+      [ "$SECONDS" -gt 20 ] && echo "oc tag ${image_name} ${namespace}/${image_tagged} did not work several times." && return 1
+      sleep 3
+      echo "oc tag ${image_name} ${namespace}/${image_tagged} did not work, trying again"
+    done
   else
     echo "Uploading image ${image_name} as ${image_tagged}"
     ct_os_upload_image "${image_name}" "${image_tagged}"

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -732,7 +732,6 @@ function ct_os_test_template_app_func() {
   local check_command=${4}
   local oc_args=${5:-}
   local other_images=${6:-}
-  local import_image=${7:-}
 
   if [ $# -lt 4 ] || [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ] || [ -z "${4}" ]; then
     echo "ERROR: ct_os_test_template_app_func() requires at least 4 arguments that cannot be emtpy." >&2
@@ -747,16 +746,13 @@ function ct_os_test_template_app_func() {
 
   # Create a specific imagestream tag for the image so that oc cannot use anything else
   if [ "${CT_SKIP_UPLOAD_IMAGE:-false}" == 'true' ] ; then
-    if [ -n "${import_image}" ] ; then
-      echo "Importing image ${import_image} as ${image_name}:${VERSION}"
-      # Use --reference-policy=local to pull remote image content to the cluster
-      # Works around the issue of builder pods not having access to registry.redhat.io
-      oc import-image "${image_name}":"${VERSION}" --from "${import_image}" --confirm --reference-policy=local
-    else
-      echo "Uploading and importing image skipped."
-    fi
+    echo "Importing image ${image_name} as ${image_tagged}"
+    # Use --reference-policy=local to pull remote image content to the cluster
+    # Works around the issue of builder pods not having access to registry.redhat.io
+    oc import-image "${image_tagged}" --from "${image_name}" --confirm --reference-policy=local
   else
-    ct_os_upload_image "${import_image:-$image_name}" "${image_tagged}"
+    echo "Uploading image ${image_name} as ${image_tagged}"
+    ct_os_upload_image "${image_name}" "${image_tagged}"
 
     # upload also other images, that template might need (list of pairs in the format <image>|<tag>
     local image_tag_a
@@ -836,7 +832,6 @@ function ct_os_test_template_app() {
   local response_code=${7:-200}
   local oc_args=${8:-}
   local other_images=${9:-}
-  local import_image=${10:-}
 
   if [ $# -lt 4 ] || [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ] || [ -z "${4}" ]; then
     echo "ERROR: ct_os_test_template_app() requires at least 4 arguments that cannot be emtpy." >&2
@@ -848,8 +843,7 @@ function ct_os_test_template_app() {
                                "${name_in_template}" \
                                "ct_os_test_response_internal '${protocol}://<IP>:${port}' '${response_code}' '${expected_output}'" \
                                "${oc_args}" \
-                               "${other_images}" \
-                               "${import_image}"
+                               "${other_images}"
 }
 
 # ct_os_test_image_update IMAGE_NAME OLD_IMAGE ISTAG CHECK_FUNCTION OC_ARGS

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -145,9 +145,9 @@ function ct_os_get_pod_status() {
 # Arguments: pod_prefix - prefix or whole ID of the pod
 function ct_os_get_build_pod_status() {
   local pod_prefix="${1}" ; shift
-  local query="custom-columns=Ready:status.containerStatuses[0].state.terminated.reason,NAME:.metadata.name"
-  oc get pods -o "$query" | grep -e "${pod_prefix}" | grep -E "\-build$" \
-                          | awk '{print $1}' | head -n 1
+  local query="custom-columns=NAME:.metadata.name,Ready:status.containerStatuses[0].state.terminated.reason"
+  oc get pods -o "$query" | grep -e "${pod_prefix}" | grep -E "\-build\s" \
+                          | sort -u | awk '{print $2}' | tail -n 1
 }
 
 # ct_os_get_pod_name POD_PREFIX

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -793,6 +793,11 @@ function ct_os_test_template_app_func() {
   local result=0
   eval "$check_command_exp" || result=1
 
+  echo "  Information about the image we work with:"
+  oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
+  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
+  oc get isimage ${image_id##*/} -o yaml
+
   if [ $result -eq 0 ] ; then
     echo "  Check passed."
   else

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -621,7 +621,7 @@ function ct_os_test_s2i_app_func() {
       echo "Importing image ${import_image} as ${image_name}:${VERSION}"
       # Use --reference-policy=local to pull remote image content to the cluster
       # Works around the issue of builder pods not having access to registry.redhat.io
-      oc import-image "${image_name}":"${VERSION}" --from "${import_image}" --confirm --reference-policy=local
+      oc tag --source=docker "${image_name}" "openshift/${image_tagged}" --insecure=true --reference-policy=local
     else
       echo "Uploading and importing image skipped."
     fi
@@ -749,7 +749,7 @@ function ct_os_test_template_app_func() {
     echo "Importing image ${image_name} as ${image_tagged}"
     # Use --reference-policy=local to pull remote image content to the cluster
     # Works around the issue of builder pods not having access to registry.redhat.io
-    oc import-image "${image_tagged}" --from "${image_name}" --confirm --reference-policy=local
+    oc tag --source=docker "${image_name}" "openshift/${image_tagged}" --insecure=true --reference-policy=local
   else
     echo "Uploading image ${image_name} as ${image_tagged}"
     ct_os_upload_image "${image_name}" "${image_tagged}"
@@ -798,7 +798,7 @@ function ct_os_test_template_app_func() {
 
   echo "  Information about the image we work with:"
   oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
-  oc get isimage "${image_id##*/}" -o yaml
+  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml
 
   if [ $result -eq 0 ] ; then
     echo "  Check passed."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -603,7 +603,6 @@ function ct_os_test_s2i_app_func() {
   local context_dir=${3}
   local check_command=${4}
   local oc_args=${5:-}
-  local import_image=${6:-}
   local image_name_no_namespace=${image_name##*/}
   local service_name="${image_name_no_namespace}-testing"
   local image_tagged="${image_name_no_namespace}:${VERSION}"
@@ -621,16 +620,13 @@ function ct_os_test_s2i_app_func() {
 
   # Create a specific imagestream tag for the image so that oc cannot use anything else
   if [ "${CT_SKIP_UPLOAD_IMAGE:-false}" == 'true' ] ; then
-    if [ -n "${import_image}" ] ; then
-      echo "Importing image ${import_image} as ${image_name}:${VERSION}"
-      # Use --reference-policy=local to pull remote image content to the cluster
-      # Works around the issue of builder pods not having access to registry.redhat.io
-      oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local
-    else
-      echo "Uploading and importing image skipped."
-    fi
+    echo "Importing image ${image_name} as ${namespace}/${image_tagged}"
+    # Use --reference-policy=local to pull remote image content to the cluster
+    # Works around the issue of builder pods not having access to registry.redhat.io
+    oc tag --source=docker "${image_name}" "${namespace}/${image_tagged}" --insecure=true --reference-policy=local
   else
-    ct_os_upload_image "${import_image:-$image_name}" "${image_tagged}"
+    echo "Uploading image ${image_name} as ${image_tagged}"
+    ct_os_upload_image "${image_name}" "${image_tagged}"
   fi
 
   local app_param="${app}"
@@ -707,7 +703,6 @@ function ct_os_test_s2i_app() {
   local protocol=${6:-http}
   local response_code=${7:-200}
   local oc_args=${8:-}
-  local import_image=${9:-}
 
   if [ $# -lt 4 ] || [ -z "${1}" ] || [ -z "${2}" ] || [ -z "${3}" ] || [ -z "${4}" ]; then
     echo "ERROR: ct_os_test_s2i_app() requires at least 4 arguments that cannot be emtpy." >&2
@@ -718,7 +713,7 @@ function ct_os_test_s2i_app() {
                           "${app}" \
                           "${context_dir}" \
                           "ct_os_test_response_internal '${protocol}://<IP>:${port}' '${response_code}' '${expected_output}'" \
-                          "${oc_args}" "${import_image}"
+                          "${oc_args}"
 }
 
 # ct_os_test_template_app_func IMAGE APP IMAGE_IN_TEMPLATE CHECK_CMD [OC_ARGS]

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -668,7 +668,8 @@ function ct_os_test_s2i_app_func() {
 
   echo "  Information about the image we work with:"
   oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
-  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml
+  # for s2i builds, the resulting image is actually in the current namespace
+  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml || oc get isimage "${image_id##*/}" -o yaml
 
   if [ $result -eq 0 ] ; then
     echo "  Check passed."
@@ -806,7 +807,8 @@ function ct_os_test_template_app_func() {
 
   echo "  Information about the image we work with:"
   oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
-  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml
+  # for s2i builds, the resulting image is actually in the current namespace
+  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml || oc get isimage "${image_id##*/}" -o yaml
 
   if [ $result -eq 0 ] ; then
     echo "  Check passed."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -785,9 +785,12 @@ function ct_os_test_template_app_func() {
   local ip
   local check_command_exp
 
+  # get image ID from the deployment config
+  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
+
   ip=$(ct_os_get_service_ip "${service_name}")
   # shellcheck disable=SC2001
-  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g")
+  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g" -e "s|<SAME_IMAGE>|${image_id}|g")
 
   echo "  Checking APP using $check_command_exp ..."
   local result=0
@@ -795,7 +798,6 @@ function ct_os_test_template_app_func() {
 
   echo "  Information about the image we work with:"
   oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
-  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
   oc get isimage "${image_id##*/}" -o yaml
 
   if [ $result -eq 0 ] ; then

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1034,7 +1034,7 @@ function ct_os_check_cmd_internal() {
   # shellcheck disable=SC2001
   check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g")
 
-  ct_os_deploy_cmd_image "$(ct_os_get_image_from_pod "${util_image_name##*/}" | head -n 1)"
+  ct_os_deploy_cmd_image "${util_image_name}"
   SECONDS=0
 
   echo -n "Waiting for ${service_name} service becoming ready ..."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1190,7 +1190,7 @@ function ct_os_test_image_stream_s2i() {
   return $result
 }
 
-# ct_os_test_image_stream_quickstart IMAGE_STREAM_FILE TEMPLATE IMAGE_NAME NAME_IN_TEMPLATE EXPECTED_OUTPUT [PORT, PROTOCOL, RESPONSE_CODE, OC_ARGS, ... ]
+# ct_os_test_image_stream_quickstart IMAGE_STREAM_FILE TEMPLATE IMAGE_NAME NAME_IN_TEMPLATE EXPECTED_OUTPUT [PORT, PROTOCOL, RESPONSE_CODE, OC_ARGS, OTHER_IMAGES ]
 # --------------------
 # Check the imagestream with an s2i app check. First it imports the given image stream, then
 # it runs [image] and [app] in the openshift and optionally specifies env_params
@@ -1205,6 +1205,10 @@ function ct_os_test_image_stream_s2i() {
 # Argument: response_code - what http response code to expect (optional; default: 200)
 # Argument: oc_args - all other arguments are used as additional parameters for the `oc new-app`
 #            command, typically environment variables (optional)
+# Argument: other_images - some templates need other image to be pushed into the OpenShift registry,
+#            specify them in this parameter as "<image>|<tag>", where "<image>" is a full image name
+#            (including registry if needed) and "<tag>" is a tag under which the image should be available
+#            in the OpenShift registry.
 function ct_os_test_image_stream_quickstart() {
   local image_stream_file=${1}
   local template_file=${2}
@@ -1215,6 +1219,7 @@ function ct_os_test_image_stream_quickstart() {
   local protocol=${7:-http}
   local response_code=${8:-200}
   local oc_args=${9:-}
+  local other_images=${10:-}
   local result
   local local_image_stream_file
   local local_template_file
@@ -1235,7 +1240,7 @@ function ct_os_test_image_stream_quickstart() {
                           "${local_template_file}" \
                           "${name_in_template}" \
                           "${expected_output}" \
-                          "${port}" "${protocol}" "${response_code}" "${oc_args}"
+                          "${port}" "${protocol}" "${response_code}" "${oc_args}" "${other_images}"
 
   result=$?
 

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -796,7 +796,7 @@ function ct_os_test_template_app_func() {
   echo "  Information about the image we work with:"
   oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
   image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
-  oc get isimage ${image_id##*/} -o yaml
+  oc get isimage "${image_id##*/}" -o yaml
 
   if [ $result -eq 0 ] ; then
     echo "  Check passed."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -254,7 +254,7 @@ function ct_os_deploy_s2i_image() {
   local image="${1}" ; shift
   local app="${1}" ; shift
   # ignore error exit code, because oc new-app returns error when image exists
-  oc new-app "${image}~${app}" "$@" || :
+  oc new-app "${image}~${app}" --strategy=source "$@" || :
 
   # let openshift cluster to sync to avoid some race condition errors
   sleep 3


### PR DESCRIPTION
This is a rather bigger re-factoring that I failed to do in smaller chunks. Hopefully tests passing in all the container images would be good enough proof it is ok to merge. I'll add links to particulars PRs in all container images repos:

- https://github.com/sclorg/s2i-python-container/pull/381
- https://github.com/sclorg/s2i-ruby-container/pull/270
- https://github.com/sclorg/s2i-nodejs-container/pull/240
- https://github.com/sclorg/s2i-perl-container/pull/177
- https://github.com/sclorg/s2i-php-container/pull/289
- https://github.com/sclorg/mariadb-container/pull/126
- https://github.com/sclorg/mysql-container/pull/288
- https://github.com/sclorg/postgresql-container/pull/378
- https://github.com/sclorg/mongodb-container/pull/319
- https://github.com/sclorg/redis-container/pull/60
- https://github.com/sclorg/httpd-container/pull/95
- https://github.com/sclorg/nginx-container/pull/112
- https://github.com/sclorg/varnish-container/pull/63