### PR TITLE
Fix issue with VERSIONS in Makefile

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -782,7 +782,8 @@ ct_check_latest_imagestreams() {
     local latest_version=
     local test_lib_dir=
 
-    latest_version=$(grep 'VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
+    # Check only lines which starts with VERSIONS
+    latest_version=$(grep '^VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
     test_lib_dir=$(dirname "$(readlink -f "$0")")
     python3 "${test_lib_dir}/check_imagestreams.py" "$latest_version"
 }


### PR DESCRIPTION
Makefile for postresql-container https://github.com/sclorg/postgresql-container/blob/master/Makefile#L5
contains two VERSIONS in case we use grep.
Line has to start with VERSIONS.

This is easy fix.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>