### PR TITLE
Fixes #138 #158. Pull image before building image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,21 +86,17 @@ function pull_image {
       continue
     fi
 
-    image_name=$(echo "$line" | cut -d ' ' -f2)
     # In case FROM scratch is defined, skip it
     if grep -q "scratch" <<< "$image_name"; then
-        continue
+      continue
     fi
-    # In case FROM ubi8 as ubi-base is mentioned
-    # pull ubi8 image
-    if grep -q " as " <<< "$line"; then
-        image_name=$(echo "$line" | cut -d ' ' -f2)
-    fi
+    image_name=$(echo "$line" | cut -d ' ' -f2)
     echo "-> Pulling image $image_name before building image from $dockerfile."
     # Sometimes in Fedora case it fails with HTTP 50X
     # Check if the image is available locally and try to pull it if it is not
-    if docker images "$image_name" &>/dev/null; then
-        continue
+    if [[ "$(docker images -q "$image_name" 2>/dev/null)" != "" ]]; then
+      echo "The image $image_name is already pulled."
+      continue
     fi
     # Try pulling the image to see if it is accessible
     if ! docker pull "$image_name"; then

--- a/build.sh
+++ b/build.sh
@@ -86,11 +86,12 @@ function pull_image {
       continue
     fi
 
+    image_name=$(echo "$line" | cut -d ' ' -f2)
+
     # In case FROM scratch is defined, skip it
-    if grep -q "scratch" <<< "$image_name"; then
+    if [[ x"$image_name" == "xscratch" ]]; then
       continue
     fi
-    image_name=$(echo "$line" | cut -d ' ' -f2)
     echo "-> Pulling image $image_name before building image from $dockerfile."
     # Sometimes in Fedora case it fails with HTTP 50X
     # Check if the image is available locally and try to pull it if it is not

--- a/build.sh
+++ b/build.sh
@@ -97,13 +97,18 @@ function pull_image {
         image_name=$(echo "$line" | cut -d ' ' -f2)
     fi
     echo "-> Pulling image $image_name before building image from $dockerfile."
-    # Try pulling the image to see if it is accessible
     # Sometimes in Fedora case it fails with HTTP 50X
+    # Check if the image is available locally and try to pull it if it is not
+    if docker images "$image_name" &>/dev/null; then
+        continue
+    fi
+    # Try pulling the image to see if it is accessible
     if ! docker pull "$image_name"; then
       echo "Pulling image $image_name failed. Let's wait 2 seconds and try one more time."
       sleep 2
       docker pull "$image_name"
     fi
+
   done < "$dockerfile"
 }
 


### PR DESCRIPTION
[EDITED] This commit fixes an error in case of e.g. Fedora registry is not
accessible for a temporary reasons like HTTP 503.
Second pulling should work usually.

In case `FROM scratch` is used in Dockerfile then it is skipped.
In case `FROM ubi8 as ubi-base` is used in Dockerfile the `ubi8` is pulled.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>