### PR TITLE
move .exclude file checks to the shell wrapper

### DIFF
--- a/check_imagestreams.py
+++ b/check_imagestreams.py
@@ -42,17 +42,6 @@ class ImageStreamChecker(object):
             return 0
         for f in json_files:
             print(f"Checking file {str(f)}.")
-            # Get os_version from stream file name
-            try:
-                os_version = str(f.stem).split("-")[1]
-            except IndexError:
-                print(f"File {str(f)} does not contain version like centos7|centos8|rhel7|rhel8|fedora.")
-                continue
-            exclude_file = p / self.version / f".exclude-{os_version}"
-            if exclude_file.exists():
-                print(f"The latest version is not supported for {os_version} yet.")
-                print(f"File {str(exclude_file)} is present.")
-                continue
             json_dict = self.load_json_file(f)
             if not (self.check_version(json_dict) and self.check_latest_tag(json_dict)):
                 print(f"The latest version is not present in {str(f)} or in latest tag.")

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -787,8 +787,17 @@ ct_check_latest_imagestreams() {
 
     # Check only lines which starts with VERSIONS
     latest_version=$(grep '^VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
-    test_lib_dir=$(dirname "$(readlink -f "$0")")
-    python3 "${test_lib_dir}/check_imagestreams.py" "$latest_version"
+    # Fall back to previous version if the latest is excluded for this OS
+    [ -f "$latest_version/.exclude-$OS" ] && latest_version=$(grep '^VERSIONS' Makefile | rev | cut -d ' ' -f 2 | rev )
+    # Only test the imagestream once, when the version matches
+    # ignore the SC warning, $VERSION is always available
+    # shellcheck disable=SC2153
+    if [ "$latest_version" == "$VERSION" ]; then
+      test_lib_dir=$(dirname "$(readlink -f "$0")")
+      python3 "${test_lib_dir}/check_imagestreams.py" "$latest_version"
+    else
+      echo "Image version $VERSION is not latest, skipping ct_check_latest_imagestreams"
+    fi
 }
 
 # ct_show_resources


### PR DESCRIPTION
The exclude file existence check was moved to the shell wrapper.
We need to check for the files only in the version that is latest.
But do not ignore the run if we find that it is excluded. Rather
take the next version down the line and run the test for it instead.
eg. when node 14 is latest in Makefile, but .exclude is found,
run the test for node 12.

Also adds additional check for limiting the test runs, so we
only run the test when the latest version matches the version
being tested.