### PR TITLE
Do not try to check imagestreams for Fedora images

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -785,6 +785,12 @@ ct_check_latest_imagestreams() {
     local latest_version=
     local test_lib_dir=
 
+    # We only maintain imagestreams for RHEL and CentOS (Community)
+    if [[ "$OS" =~ ^fedora.* ]] ; then
+      echo "Imagestreams for Fedora are not maintained, skipping ct_check_latest_imagestreams"
+      exit 0
+    fi
+
     # Check only lines which starts with VERSIONS
     latest_version=$(grep '^VERSIONS' Makefile | rev | cut -d ' ' -f 1 | rev )
     # Fall back to previous version if the latest is excluded for this OS


### PR DESCRIPTION
Should help https://github.com/sclorg/s2i-nodejs-container/pull/254 to pass for Fedora image.