### PR TITLE
This fixes problem with tagging image for external registry

### DIFF
--- a/test-remote-cluster.sh
+++ b/test-remote-cluster.sh
@@ -23,7 +23,7 @@ export REGISTRY
 for dir in ${VERSIONS}; do
   pushd "${dir}" > /dev/null
 
-  export IMAGE_NAME="${REGISTRY}${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
+  export IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
   if [[ -x test/run-openshift-remote-cluster ]]; then
     VERSION="${dir}" test/run-openshift-remote-cluster


### PR DESCRIPTION
See error:
https://gist.github.com/rhscl-automation/15901ed849d46c176c7b13afa64e8abf

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>