### PR TITLE
Missing which and too fast failures

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -341,7 +341,7 @@ function ct_binary_found_from_df() {
   # Create Dockerfile that looks for the binary
   cat <<EOF >"$tmpdir/Dockerfile"
 FROM $IMAGE_NAME
-RUN which $binary | grep "$binary_path"
+RUN command -v $binary | grep "$binary_path"
 EOF
   # Build an image, looking for expected path in the output
   if ! docker build -f "$tmpdir/Dockerfile" --no-cache "$tmpdir"; then

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -27,7 +27,7 @@ EXPECTED_EXIT_CODE=0
 function ct_cleanup() {
   ct_show_resources
   for cid_file in "$CID_FILE_DIR"/* ; do
-    [ -f "$cid_file" ] || break
+    [ -f "$cid_file" ] || continue
     local container
     container=$(cat "$cid_file")
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -27,6 +27,7 @@ EXPECTED_EXIT_CODE=0
 function ct_cleanup() {
   ct_show_resources
   for cid_file in "$CID_FILE_DIR"/* ; do
+    [ -f "$cid_file" ] || break
     local container
     container=$(cat "$cid_file")
 


### PR DESCRIPTION
We don't have `which` in all containers. Also, in some cases when, when tests fail before the first container is created, the cleanup can fail by trying to remote empty string.