### PR TITLE
Add support for quay.io for CentOS7 images

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -51,11 +51,13 @@ else ifeq ($(TARGET),centos8)
 else
 	OS := centos7
 	DOCKERFILE ?= Dockerfile
+	REGISTRY := "quay.io/"
 endif
 
 SKIP_SQUASH ?= 1
 DOCKER_BUILD_CONTEXT ?= .
 SHELLCHECK_FILES ?= .
+REGISTRY ?= ""
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
@@ -64,7 +66,8 @@ script_env = \
 	CLEAN_AFTER=$(CLEAN_AFTER)                      \
 	DOCKER_BUILD_CONTEXT=$(DOCKER_BUILD_CONTEXT)    \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"  \
-	CUSTOM_REPO="$(CUSTOM_REPO)"
+	CUSTOM_REPO="$(CUSTOM_REPO)" \
+	REGISTRY="$(REGISTRY)"
 
 # TODO: switch to 'build: build-all' once parallel builds are relatively safe
 .PHONY: build build-serial build-all

--- a/tag.sh
+++ b/tag.sh
@@ -18,11 +18,11 @@ for dir in ${VERSIONS}; do
   commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
   date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
 
-
-  echo "-> Tagging image '$IMAGE_ID' as '$REGISTRY$name:$version' and '$REGISTRY$name:latest' and '$REGISTRY$name:$date_and_hash'"
-  docker tag "$IMAGE_ID" "$REGISTRY$name:$version"
-  docker tag "$IMAGE_ID" "$REGISTRY$name:latest"
-  docker tag "$IMAGE_ID" "$REGISTRY$name:$date_and_hash"
+  full_reg_name="$REGISTRY$name"
+  echo "-> Tagging image '$IMAGE_ID' as '$full_reg_name:$version' and '$full_reg_name:latest' and '$full_reg_name:$date_and_hash'"
+  docker tag "$IMAGE_ID" "$full_reg_name:$version"
+  docker tag "$IMAGE_ID" "$full_reg_name:latest"
+  docker tag "$IMAGE_ID" "$full_reg_name:$date_and_hash"
 
   for suffix in squashed raw; do
     id_file=.image-id.$suffix

--- a/tag.sh
+++ b/tag.sh
@@ -18,10 +18,11 @@ for dir in ${VERSIONS}; do
   commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
   date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
 
-  echo "-> Tagging image '$IMAGE_ID' as '$name:$version' and '$name:latest' and '$name:$date_and_hash'"
-  docker tag "$IMAGE_ID" "$name:$version"
-  docker tag "$IMAGE_ID" "$name:latest"
-  docker tag "$IMAGE_ID" "$name:$date_and_hash"
+
+  echo "-> Tagging image '$IMAGE_ID' as '$REGISTRY$name:$version' and '$REGISTRY$name:latest' and '$REGISTRY$name:$date_and_hash'"
+  docker tag "$IMAGE_ID" "$REGISTRY$name:$version"
+  docker tag "$IMAGE_ID" "$REGISTRY$name:latest"
+  docker tag "$IMAGE_ID" "$REGISTRY$name:$date_and_hash"
 
   for suffix in squashed raw; do
     id_file=.image-id.$suffix

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -560,7 +560,7 @@ ct_registry_from_os() {
         registry=registry.redhat.io
         ;;
     *)
-        registry=docker.io
+        registry=quay.io
         ;;
     esac
   echo "$registry"
@@ -586,9 +586,9 @@ ct_get_public_image_name() {
   elif [ "x$os" == "xrhel8" ]; then
     public_image_name=$registry/rhel8/$base_image_name-${version//./}
   elif [ "x$os" == "xcentos7" ]; then
-    public_image_name=$registry/centos/$base_image_name-${version//./}-centos7
+    public_image_name=$registry/centos7/$base_image_name-${version//./}-centos7
   elif [ "x$os" == "xcentos8" ]; then
-    public_image_name=$registry/centos/$base_image_name-${version//./}-centos8
+    public_image_name=$registry/centos8/$base_image_name-${version//./}-centos8
   fi
 
   echo "$public_image_name"

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,11 @@ for dir in ${VERSIONS}; do
   IMAGE_VERSION=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
   # Kept also IMAGE_NAME as some tests might still use that.
   IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$IMAGE_VERSION"
-  export IMAGE_NAME
+  if [ x"${OS}" == "xcentos7" ]; then
+    export IMAGE_NAME="$REGISTRY$IMAGE_NAME"
+  else
+    export IMAGE_NAME
+  fi
 
   if [ -n "${TEST_MODE}" ]; then
     VERSION=$dir test/run

--- a/tests/test-lib/image_availability
+++ b/tests/test-lib/image_availability
@@ -5,13 +5,13 @@ set -e
 . test-lib.sh
 
 # This should succeed
-if ! ct_check_image_availability docker.io/centos/postgresql-10-centos7; then
+if ! ct_check_image_availability quay.io/centos7/ruby-27-centos7; then
   echo "image_availability test failed"
   false
 fi
 
 # This should fail
-if ct_check_image_availability docker.io/centos/postgresql-98-centos7; then
+if ct_check_image_availability quay.io/centos7/ruby-24-centos7; then
   echo "image_availability test failed"
   false
 fi

--- a/tests/test-lib/public_image_name
+++ b/tests/test-lib/public_image_name
@@ -5,7 +5,7 @@ set -e
 . test-lib.sh
 
 combinations="rhel7:registry.redhat.io/rhscl/postgresql-10-rhel7
-centos7:docker.io/centos/postgresql-10-centos7
+centos7:quay.io/centos7/postgresql-10-centos7
 rhel8:registry.redhat.io/rhel8/postgresql-10
 "
 


### PR DESCRIPTION
This pull request adds support for quay.io registry.
All RHSCL CentOS images will be soon moved into quay.io registry because of docker pull rate limit.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>