### PR TITLE
Add possibility to use a development repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -139,6 +139,21 @@ function docker_build_with_version {
     BUILD_OPTIONS+=" --pull=true"
   fi
 
+  # Add possibility to use a development repo
+  #
+  # This is useful if we want to work with RPMs that are not available publically yet.
+  #
+  # How to use it:
+  # First, we create a file that only tells the scripts to use the development repository,
+  # e.g. .devel-repo-rhel8, similarly as we use .exclude-rhel8 for excluding particular
+  # variant of the Dockerfile.
+  #
+  # If such a file exists in the repository, then the building scripts will take a look
+  # at a correspondent variable, e.g.  DEVEL_REPO_rhel8, and will use the repository file
+  # defined by that variable.
+  #
+  # That means that definition of the DEVEL_REPO_rhel8 variable is a responsibility of
+  # the test/CI environment.
   if [ -f "$devel_repo_file" ] && [[ -v "$devel_repo_var" ]] ; then
     CUSTOM_REPO=$(mktemp)
     curl -Lk "${!devel_repo_var}" >"${CUSTOM_REPO}"

--- a/build.sh
+++ b/build.sh
@@ -147,7 +147,7 @@ function docker_build_with_version {
   # How to use it:
   # First, we create a file that only tells the scripts to use the development repository,
   # e.g. .devel-repo-rhel8, similarly as we use .exclude-rhel8 for excluding particular
-  # variant of the Dockerfile.
+  # variant of the Dockerfile. Content of the file is not important at this point.
   #
   # If such a file exists in the repository, then the building scripts will take a look
   # at a correspondent variable, e.g.  DEVEL_REPO_rhel8, and will use the repository file

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,7 @@ _parse_output_inner ()
 parse_output ()
 {
   local command=$1 filter=$2 var=$3 stream=$4
+  echo "-> building using $command"
   local raw_output='' rc=0
   {
       # shellcheck disable=SC2034

--- a/build.sh
+++ b/build.sh
@@ -119,6 +119,8 @@ function pull_image {
 function docker_build_with_version {
   local dockerfile="$1"
   local exclude=.exclude-${OS}
+  local devel_repo_file=.devel-repo-${OS}
+  local devel_repo_var="DEVEL_REPO_$OS"
   if [ -e "$exclude" ]; then
     echo "-> $exclude file exists for version $dir, skipping build."
     clean_image
@@ -136,6 +138,13 @@ function docker_build_with_version {
   if [[ "${UPDATE_BASE}" == "1" ]]; then
     BUILD_OPTIONS+=" --pull=true"
   fi
+
+  if [ -f "$devel_repo_file" ] && [[ -v "$devel_repo_var" ]] ; then
+    CUSTOM_REPO=$(mktemp)
+    curl -Lk "${!devel_repo_var}" >"${CUSTOM_REPO}"
+    echo "-> $devel_repo_file file exists for version $dir, so using ${!devel_repo_var}."
+  fi
+
   if [ -n "$CUSTOM_REPO" ]; then
     if [ -f "$CUSTOM_REPO" ]; then
       BUILD_OPTIONS+=" -v $CUSTOM_REPO:/etc/yum.repos.d/sclorg_custom.repo:Z"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -818,7 +818,7 @@ ct_show_resources()
   echo "Memory:"
   free -h
   echo "Storage:"
-  df -h
+  df -h || :
   echo "CPU"
   lscpu
 }


### PR DESCRIPTION
This is useful if we want to work with RPMs that are not available publically yet.

How to use it:
First, we create a file that only tells the scripts to use the development repository,
e.g. .devel-repo-rhel8, similarly as we use .exclude-rhel8 for excluding particular
variant of the Dockerfile.

If such a file exists in the repository, then the building scripts will take a look
at a correspondent variable, e.g.  DEVEL_REPO_rhel8, and will use the repository file
defined by that variable.

That means that definition of the DEVEL_REPO_rhel8 variable is a responsibility of
the test/CI environment.