### PR TITLE
This PR deprecates conu in SCL containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,6 @@ Similar to `make test` but runs testsuite for Openshift 3, expected to be found 
 Similar to `make test` but runs testsuite for Openshift 4, expected to be found at
 `$gitroot/$version/test/run-openshift-remote-cluster`
 
-`make test-with-conu`  
-The rule is similar to `make test`. It runs a test suite written using [conu
-library](https://github.com/user-cont/conu). The path to the test script is
-meant to be at `$gitroot/$version/test/run-conu`. By default the test suite is
-being run in the current environment. You can also run the tests in a container
-by defining variable `CONU_IMAGE`. Container images with conu are available in
-[this docker hub repository](docker.io/usercont/conu:0.6.2), a good value for
-the variable is `docker.io/usercont/conu:0.6.2`.
-
 `make clean`  
 Runs scripts that clean-up the working dir. Depends on the `clean-images` rule by default
 and additional clean rules can be provided through the `clean-hook` variable.

--- a/common.mk
+++ b/common.mk
@@ -96,11 +96,6 @@ test: script_env += TEST_MODE=true
 test: tag
 	VERSIONS="$(VERSIONS)" $(script_env) $(test)
 
-.PHONY: test-with-conu
-test-with-conu: script_env += TEST_CONU_MODE=true
-test-with-conu: tag
-	VERSIONS="$(VERSIONS)" $(script_env) $(test)
-
 .PHONY: test-openshift-4
 test-openshift-4: script_env += TEST_OPENSHIFT_4=true
 test-openshift-4: tag

--- a/test.sh
+++ b/test.sh
@@ -26,31 +26,6 @@ for dir in ${VERSIONS}; do
     VERSION=$dir test/run
   fi
 
-  if [ -n "${TEST_CONU_MODE}" ]; then
-    if [[ -x test/run-conu ]]; then
-      if [ -n "${CONU_IMAGE}" ]; then
-        echo "-> Running conu tests in a container"
-        docker run \
-          --net=host \
-          -e VERSION="${dir}" \
-          -e IMAGE_NAME \
-          --rm \
-          --security-opt label=disable \
-          -ti \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          -v "${PWD}"/../:/src \
-          -w "/src/${dir}/" \
-          -ti \
-          "${CONU_IMAGE}" \
-          ./test/run-conu
-      else
-        VERSION="${dir}" ./test/run-conu
-      fi
-    else
-      echo "-> conu tests are not present, skipping"
-    fi
-  fi
-
   if [ -n "${TEST_OPENSHIFT_4}" ]; then
     if [[ -x test/run-openshift-remote-cluster ]]; then
         VERSION=$dir test/run-openshift-remote-cluster


### PR DESCRIPTION
conu is failing https://github.com/sclorg/s2i-ruby-container/pull/317. Let's remove all conu tests for ALL our containers.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>