### PR TITLE
Add more logs into OpenShift failure cases

### DIFF
--- a/tests/squash/squash.sh
+++ b/tests/squash/squash.sh
@@ -8,7 +8,7 @@ if grep -q "Red Hat Enterprise Linux release 8" /etc/system-release; then
   exit 0
 fi
 
-origin=quay.io/centos7/s2i-core-centos7
+origin=quay.io/quay/busybox
 squash=$(dirname "$(readlink -f "$0")")/../../squash.py
 cd "$(dirname "$0")"
 

--- a/tests/squash/squash.sh
+++ b/tests/squash/squash.sh
@@ -8,7 +8,7 @@ if grep -q "Red Hat Enterprise Linux release 8" /etc/system-release; then
   exit 0
 fi
 
-origin=busybox
+origin=quay.io/centos7/s2i-core-centos7
 squash=$(dirname "$(readlink -f "$0")")/../../squash.py
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
This pull request adds more logs in case RHSCL image builds are failing.

E.g. When we are building s2i images, we do not know reason, why it failed.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>