### PR TITLE
Add support 'make betka'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,8 @@ check-squash:
 check-latest-imagestream:
 	cd tests && ./check_imagestreams.sh
 
+check-betka:
+	cd tests && ./check_betka.sh
+
 check: check-failures check-squash check-latest-imagestream
 	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Similar to `make test` but runs testsuite for Openshift 3, expected to be found 
 Similar to `make test` but runs testsuite for Openshift 4, expected to be found at
 `$gitroot/$version/test/run-openshift-remote-cluster`
 
+`make betka`
+Runs script betka.sh that generates sources for the dist-git repo. Only Fedora,
+RHEL7 and RHEL8 are supported.
+For source generation into Fedora or RHEL dist-git repositories,
+some parameters are mandatory.
+DOCKER_IMAGE parameter for Fedora case is `quay.io/rhscl/cwt-generator`,
+for RHEL world please ask pkubat@redhat.com, phracek@redhat.com, or hhorak@redhat.com.
+
+E.g. command for the source generation into Fedora dist-repo
+`https://src.fedoraproject.org/container/nodejs` into main branch is:
+`make betka TARGET=fedora VERSIONS=12`
+
+The sources are not generated directly into dist-git repository,
+but into created `results` directory.
+
 `make clean`  
 Runs scripts that clean-up the working dir. Depends on the `clean-images` rule by default
 and additional clean rules can be provided through the `clean-hook` variable.

--- a/betka.py
+++ b/betka.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 import os
-import pathlib
 import subprocess
 import sys
 import shutil

--- a/betka.py
+++ b/betka.py
@@ -194,7 +194,7 @@ class BetkaGenerator(object):
             shutil.copytree(self.cur_dir, f"{p}", symlinks=True)
 
     def generate_sources(self, downstream_name: str):
-        cmd = f"docker run -it --rm -v {pathlib.Path.home()}/.gitconfig:/root/.gitconfig:ro,Z " \
+        cmd = f"docker run -it --rm -v {Path.home()}/.gitconfig:/root/.gitconfig:ro,Z " \
               f"-v {self.betka_tmp_dir.name}:{self.betka_tmp_dir.name}:rw,Z -e WORKDIR={self.betka_tmp_dir.name} " \
               f"-e DOWNSTREAM_IMAGE_NAME={downstream_name} " \
               f"-e UPSTREAM_IMAGE_NAME={self.upstream_image_name} {self.cwt_docker_image}"

--- a/betka.py
+++ b/betka.py
@@ -1,0 +1,233 @@
+#!/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import pathlib
+import subprocess
+import sys
+import shutil
+
+from typing import List
+from pathlib import Path
+from contextlib import contextmanager
+from os import getenv
+from tempfile import TemporaryDirectory
+
+
+def run_cmd(cmd, return_output=False, ignore_error=False, shell=False, **kwargs):
+    """
+    Run provided command on host system using the same user as invoked this code.
+    Raises subprocess.CalledProcessError if it fails.
+    :param cmd: list or str
+    :param return_output: bool, return output of the command
+    :param ignore_error: bool, do not fail in case nonzero return code
+    :param shell: bool, run command in shell
+    :param kwargs: pass keyword arguments to subprocess.check_* functions; for more info,
+            please check `help(subprocess.Popen)`
+    :return: None or str
+    """
+    print(f"command: {cmd}")
+    try:
+        if return_output:
+            return subprocess.check_output(
+                cmd,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                shell=shell,
+                **kwargs,
+            )
+        else:
+            return subprocess.check_call(cmd, shell=shell, **kwargs)
+    except subprocess.CalledProcessError as cpe:
+        if ignore_error:
+            if return_output:
+                return cpe.output
+            else:
+                return cpe.returncode
+        else:
+            print(f"ERROR: failed with code {cpe.returncode} and output:\n{cpe.output}")
+            raise cpe
+
+
+@contextmanager
+def cwd(target):
+    """
+    Manage cwd in a pushd/popd fashion.
+    Usage:
+    with cwd(tmpdir):
+      do something in tmpdir
+    """
+    curdir = os.getcwd()
+    os.chdir(target)
+    try:
+        yield
+    finally:
+        os.chdir(curdir)
+
+
+class BetkaGenerator(object):
+
+    def __init__(self):
+        self.betka_tmp_dir = None
+        self.os_env: str = getenv("OS")
+        self.versions_env: str = getenv("VERSIONS")
+        self.cwt_docker_image: str = getenv("CWT_DOCKER_IMAGE")
+        self.downstream_branch: str = getenv("DOWNSTREAM_BRANCH")
+        self.clone_url: str = getenv("CLONE_URL")
+        self.cur_dir: Path = Path.cwd()
+        self.cwt_command = "cwt"
+        self.cwt_config = "default.yaml"
+        self.upstream_image_name = self.cur_dir.name
+        self.ups_sources = ""
+
+    def check_requirements(self) -> bool:
+        if self.os_env == "centos7":
+            msg = f"Target has to be specified.\n"\
+                  "CentOS7 is not supported.\n"\
+                  "e.g. make betka TARGET=fedora VERSIONS=XY\n"
+            print(msg)
+            return False
+        if self.cwt_docker_image == "":
+            msg = f"Docker image for generating dist-git sources for RHEL has to be specified.\n"\
+                  "Ask pkubat@redhat.com, hhorak@redhat.com or phracek@redhat.com for the name."
+            print(msg)
+            return False
+        if self.os_env == "fedora":
+            if not self.downstream_branch:
+                self.cwt_config = "default.yaml"
+            else:
+                # Examples config for F34 is f34.yaml
+                # For more configs see
+                # https://github.com/sclorg/container-workflow-tool/tree/master/container_workflow_tool/config
+                self.cwt_config = f"{self.downstream_branch}.yaml"
+        else:
+            if not self.downstream_branch or self.downstream_branch == "":
+                msg = f"DOWNSTREAM_BRANCH is not specified.\n" \
+                      f"Examples:\n" \
+                      f"rhel-8.3.0 for RHEL8\n" \
+                      f"rhscl-3.6-rhel7 for RHEL7\n" \
+                      f"For more details ask pkubat@redhat.com or phracek@redhat.com\n"
+                print(msg)
+                return False
+            self.cwt_command = "rhcwt"
+        git_config = Path(pathlib.Path.home()) / ".gitconfig"
+        if not git_config.exists():
+            msg = f"File {git_config} is mandatory for using CWT tool." \
+                  f"Create it by commands:" \
+                  f"git config --global user.mail <your mail>" \
+                  f"git config --global user.name <your name>"
+            print(msg)
+            return False
+        return True
+
+    def delete_generated_dirs(self, ver: str):
+        results_dir: Path = self.cur_dir / f"results-{ver}"
+        if results_dir.exists():
+            print(f"Results dir {results_dir} already exists. Delete it.")
+            shutil.rmtree(results_dir)
+
+    def get_valid_images(self, ver) -> List[str]:
+        if self.os_env != "fedora":
+            self.convert_branch_to_cwt_tool()
+        cmd = f"docker run -it --rm {self.cwt_docker_image} bash -c '{self.cwt_command}" \
+              f" --config={self.cwt_config} utils listupstream'"
+        docker_output = run_cmd(cmd, return_output=True, shell=True)
+        valid_images = []
+        for x in docker_output.split('\n'):
+            # Fields are:
+            # python-27 python-27 s2i-python-container https://github.com/sclorg/s2i-python-container.git 2.7 rhel-8.4.0
+            if self.upstream_image_name in x and ver == x.split(' ')[4]:
+                valid_images.append(x)
+        print(f"Valid images {valid_images}")
+        return valid_images
+
+    def convert_branch_to_cwt_tool(self):
+        fields = self.downstream_branch.split('-')
+        if self.os_env == "rhel7":
+            self.cwt_config = f"rhel7.yaml:{fields[0]}{fields[1].replace('.','')}"
+        else:
+            release_fields = fields[1].split('.')
+            self.cwt_config = f"rhel8.yaml:{fields[0]}{release_fields[0]}.{release_fields[1]}"
+
+    def check_parameters(self):
+        if self.os_env == "fedora":
+            msg = f"For generating dist-git sources to Fedora {self.cwt_docker_image} is used." \
+                  f"'make betka' will try to sync main branch in Fedora land." \
+                  f"If you want to change it then specify it by parameter DOWNSTREAM_BRANCH," \
+                  f"like 'make betka TARGET=fedora DOWNSTREAM_BRANCH=f32'"
+            print(msg)
+        if self.os_env == "centos7":
+            return 1
+
+    def clone_and_switch_to_branch(self, downstream_name: str, branch_name: str):
+        cmd = f"git clone {self.clone_url}/{downstream_name} {self.betka_tmp_dir.name}/results"
+        run_cmd(cmd, shell=True)
+        with cwd(f"{self.betka_tmp_dir.name}/results"):
+            cmd = f"git checkout {branch_name}"
+            run_cmd(cmd, shell=True)
+
+    def copy_upstream_sources(self):
+        p = Path(f"{self.betka_tmp_dir.name}/{self.upstream_image_name}")
+        if not p.exists():
+            print(f"Upstream sources are copied to {p}")
+            shutil.copytree(self.cur_dir, f"{p}", symlinks=True)
+
+    def generate_sources(self, downstream_name: str):
+        cmd = f"docker run -it --rm -v {pathlib.Path.home()}/.gitconfig:/root/.gitconfig:ro,Z " \
+              f"-v {self.betka_tmp_dir.name}:{self.betka_tmp_dir.name}:rw,Z -e WORKDIR={self.betka_tmp_dir.name} " \
+              f"-e DOWNSTREAM_IMAGE_NAME={downstream_name} " \
+              f"-e UPSTREAM_IMAGE_NAME={self.upstream_image_name} {self.cwt_docker_image}"
+        run_cmd(cmd, shell=True)
+
+    def copy_generated_source(self, ver: str):
+        shutil.copytree(self.ups_sources, self.cur_dir / f"results-{ver}", symlinks=True)
+
+    def convert_sources(self):
+        generated_sources = []
+        if not self.versions_env or self.versions_env == "":
+            return 1
+        for ver in self.versions_env.split(' '):
+            with cwd(str(self.cur_dir / ver)):
+                self.delete_generated_dirs(ver)
+                valid_images = self.get_valid_images(ver)
+                for img in valid_images:
+                    self.betka_tmp_dir = TemporaryDirectory()
+                    img_fields = img.split()
+                    self.ups_sources = f"{self.betka_tmp_dir.name}/{self.upstream_image_name}"
+                    self.copy_upstream_sources()
+                    self.clone_and_switch_to_branch(downstream_name=img_fields[0], branch_name=img_fields[5])
+                    self.generate_sources(downstream_name=img_fields[0])
+                    self.copy_generated_source(ver=img_fields[4])
+                    generated_sources.append(f"results-{ver}")
+                    self.betka_tmp_dir.cleanup()
+        if generated_sources:
+            print("Dist-git sources generated by 'make betka' are stored in this/these directories:")
+            print('\n'.join(generated_sources))
+
+
+if __name__ == "__main__":
+    bg = BetkaGenerator()
+    if not bg.check_requirements():
+        sys.exit(1)
+    sys.exit(bg.convert_sources())

--- a/betka.py
+++ b/betka.py
@@ -206,7 +206,7 @@ class BetkaGenerator(object):
         generated_sources = []
         if not self.versions_env:
             return 1
-        for ver in self.versions_env.split(' '):
+        for ver in self.versions_env.split():
             with cwd(str(self.cur_dir / ver)):
                 self.delete_generated_dirs(ver)
                 valid_images = self.get_valid_images(ver)

--- a/betka.py
+++ b/betka.py
@@ -120,7 +120,7 @@ e.g. make betka TARGET=fedora VERSIONS=XY
             """
             logging.info(msg)
             return False
-        if self.cwt_docker_image == "":
+        if not self.cwt_docker_image:
             msg = """
 Docker image for generating dist-git sources for RHEL has to be specified.
 Ask pkubat@redhat.com, hhorak@redhat.com or phracek@redhat.com for the name.
@@ -173,8 +173,9 @@ git config --global user.name <your name>
     def get_valid_images(self, ver: str) -> List[str]:
         if self.os_env != "fedora":
             self.convert_branch_to_cwt_tool()
-        cmd = f"docker run -it --rm {self.cwt_docker_image} bash -c '{self.cwt_command}" \
-              f" --config={self.cwt_config} utils listupstream'"
+        cmd = f"""docker run -it --rm {self.cwt_docker_image} bash -c '{self.cwt_command} \
+--config={self.cwt_config} utils listupstream'
+"""
         docker_output = run_cmd(cmd, return_output=True, shell=True)
         valid_images = []
         for line in docker_output.split('\n'):

--- a/betka.py
+++ b/betka.py
@@ -205,7 +205,7 @@ class BetkaGenerator(object):
 
     def convert_sources(self):
         generated_sources = []
-        if not self.versions_env or self.versions_env == "":
+        if not self.versions_env:
             return 1
         for ver in self.versions_env.split(' '):
             with cwd(str(self.cur_dir / ver)):

--- a/betka.py
+++ b/betka.py
@@ -122,7 +122,7 @@ class BetkaGenerator(object):
                 # https://github.com/sclorg/container-workflow-tool/tree/master/container_workflow_tool/config
                 self.cwt_config = f"{self.downstream_branch}.yaml"
         else:
-            if not self.downstream_branch or self.downstream_branch == "":
+            if not self.downstream_branch:
                 msg = f"DOWNSTREAM_BRANCH is not specified.\n" \
                       f"Examples:\n" \
                       f"rhel-8.3.0 for RHEL8\n" \

--- a/betka.sh
+++ b/betka.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script is used to build images for dist-git repositories.
+#
+# The result directory will contain generated sources from upstream directories
+#
+
+set -ex
+
+function load_configuration() {
+  if [[ x"${OS}" == "xfedora" ]]; then
+    HTTP_CODE=$(curl --output cwt_config --silent --write-out "%{http_code}" -L https://raw.githubusercontent.com/sclorg/container-workflow-tool/master/cwt_generator.config)
+    if [[ ${HTTP_CODE} == 404 ]]; then
+      exit 1
+    fi
+  else
+    HTTP_CODE=$(curl --output cwt_config --silent --write-out "%{http_code}" -L https://url.corp.redhat.com/rhcwt_config)
+    if [[ ${HTTP_CODE} == 404 ]]; then
+      exit 1
+    fi
+  fi
+  # shellcheck disable=SC1091
+  source cwt_config
+}
+
+function pull_cwt_image() {
+  if ! docker images "${CWT_DOCKER_IMAGE}" &>/dev/null; then
+    echo "Docker image ${CWT_DOCKER_IMAGE} does not exist on the system. Let's pull it."
+    docker pull "${CWT_DOCKER_IMAGE}"
+  fi
+}
+TEST_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+load_configuration
+pull_cwt_image
+
+python3 "${TEST_DIR}/betka.py"

--- a/clean.sh
+++ b/clean.sh
@@ -7,7 +7,7 @@ for version
 do
     remove_images=
     for idfile in .image-id.raw .image-id.squashed; do
-        # shellcheck disable=SC2039
+        # shellcheck disable=SC2039,SC3024
         test ! -f "$version/$idfile" || remove_images+=" $(cat "$version/$idfile")"
     done
 

--- a/common.mk
+++ b/common.mk
@@ -15,6 +15,7 @@ testr = $(SHELL) $(common_dir)/test-remote-cluster.sh
 shellcheck =  $(SHELL) $(common_dir)/run-shellcheck.sh
 tag =   $(SHELL) $(common_dir)/tag.sh
 clean = $(SHELL) $(common_dir)/clean.sh
+betka = $(SHELL) $(common_dir)/betka.sh
 
 DG ?= /bin/dg
 
@@ -113,6 +114,13 @@ shellcheck:
 .PHONY: tag
 tag: build
 	VERSIONS="$(VERSIONS)" $(script_env) $(tag)
+
+.PHOHY: betka
+betka:
+	VERSIONS="$(VERSIONS)" \
+    DOWNSTREAM_NAME="$(DOWNSTREAM_NAME)" \
+    DOCKER_IMAGE="$(DOCKER_IMAGE)" \
+    $(script_env) $(betka)
 
 .PHONY: clean clean-hook clean-images clean-versions
 clean: clean-images

--- a/tests/check_betka.sh
+++ b/tests/check_betka.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -x
+
+betka=$(dirname "$(readlink -f "$0")")/../betka.sh
+
+# CentOS7 is not support for make betka
+bash $betka OS=centos7
+test $? -eq 1
+
+# DOWNSTREAM_NAME is missing
+OS=fedora bash $betka
+test $? -eq 1
+
+# DOWNSTREAM_NAME is missing
+OS=fedora DOWNSTREAM_BRANCH=f32 bash $betka
+test $? -eq 1
+
+# DOCKER_IMAGE is missing
+bash $betka OS=rhel7
+test $? -eq 1
+
+# DOWNSTREAM_NAME is missing
+bash $betka OS=rhel7 DOCKER_IMAGE="quay.io/rhscl/dummy"
+test $? -eq 1
+
+# DOWNSTREAM_BRANCH is missing
+bash $betka OS=rhel7 DOCKER_IMAGE="quay.io/rhscl/dummy" DOWNSTREAM_NAME="foo_test"
+test $? -eq 1


### PR DESCRIPTION
This PR adds new functionality to generate downstream sources based on the upstream sources.

What is covered by this pull request:
- [x] centos7 is not supported and checked in the scripts. There is no plan to support it.
- [x] fedora is supported. If DOWNSTREAM_BRANCH is not specified, then `main` is default. `master` does not exist at all. DOWNSTREAM_NAME has to be specified.
- [x] rhel is supported. DOWNSTREAM_NAME has to be specified because we don't know what to generate. DOCKER_IMAGE has to be specified. Like `rh-nodejs10`. DOWNSTREAM_BRANCH has to be specified, like `rhel-8.4.0` or `rhscl-3.6-rhel7`
- [x] tests are covered also for `make betka`
- [x] Documentation updated

There is a PR https://github.com/sclorg/container-workflow-tool/pull/28 which fixes correct Dockerfile tag generation.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>