### PR TITLE
Support local application in ct_test_app_dockerfile

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -827,7 +827,7 @@ ct_show_resources()
 # -----------------------------
 # Argument: dockerfile - path to a Dockerfile that will be used for building an image
 #                        (must work with an application directory called 'app-src')
-# Argument: app_url - git URI with a testing application, supports "@" to indicate a different branch
+# Argument: app_url - git or local URI with a testing application, supports "@" to indicate a different branch
 # Argument: body_regexp - PCRE regular expression that must match the response body
 # Argument: app_dir - name of the application directory that is used in the Dockerfile
 # Argument: port - Optional port number (default: 8080)
@@ -865,20 +865,25 @@ ct_test_app_dockerfile() {
   echo "Using this Dockerfile:"
   cat Dockerfile
 
-  # If app_url contains @, the string after @ is considered
-  # as a name of a branch to clone instead of the main/master branch
-  IFS='@' read -ra git_url_parts <<< "${app_url}"
-
-  if [ -n "${git_url_parts[1]}" ]; then
-    git_clone_cmd="git clone --branch ${git_url_parts[1]} ${git_url_parts[0]} ${app_dir}"
+  if [ -d "$app_url" ] ; then
+    echo "Copying local folder: $app_url -> $app_dir."
+    cp -Lr $app_url $app_dir
   else
-    git_clone_cmd="git clone ${app_url} ${app_dir}"
-  fi
+    # If app_url contains @, the string after @ is considered
+    # as a name of a branch to clone instead of the main/master branch
+    IFS='@' read -ra git_url_parts <<< "${app_url}"
 
-  if ! $git_clone_cmd ; then
-    echo "ERROR: Git repository ${app_url} cannot be cloned into ${app_dir}."
-    echo "Terminating the Dockerfile build."
-    return 1
+    if [ -n "${git_url_parts[1]}" ]; then
+      git_clone_cmd="git clone --branch ${git_url_parts[1]} ${git_url_parts[0]} ${app_dir}"
+    else
+      git_clone_cmd="git clone ${app_url} ${app_dir}"
+    fi
+
+    if ! $git_clone_cmd ; then
+      echo "ERROR: Git repository ${app_url} cannot be cloned into ${app_dir}."
+      echo "Terminating the Dockerfile build."
+      return 1
+    fi
   fi
 
   echo "Building '${app_image_name}' image using docker build"


### PR DESCRIPTION
If $app_url contains `.git`, it's cloned from the URI. If not and
it exists as a folder locally, it's just copied via cp to $app_dir.

I'm testing this in Python container when I need to test something "from dockerfile" but with a local test application we already have in the same repository.