### PR TITLE
Allow distgen to be skipped for a specific versions

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -144,6 +144,7 @@ MANIFEST_FILE ?= manifest.sh
 auto_targets.mk: $(MANIFEST_FILE)
 	MANIFEST_FILE="$(MANIFEST_FILE)" \
 	VERSIONS="$(VERSIONS)" \
+	SKIP_GENERATOR_FOR="${SKIP_GENERATOR_FOR}" \
 	$(generator)
 
 # triggers build of auto_targets.mk automatically

--- a/generate.sh
+++ b/generate.sh
@@ -120,6 +120,9 @@ EOF
 }
 
 for version in ${VERSIONS}; do
+    # SKIP_GENERATOR_FOR is an array of versions we don't generate
+    # via distgen and therefore missing configuration is not a problem.
+    [[ ${SKIP_GENERATOR_FOR[*]} =~ (^|[[:space:]])"${version}"($|[[:space:]]) ]] && continue
     # Get a working combination of distgen options for this version
     while read -r combination; do
         # line looks like: --distro rhel-7-x86_64.yaml --multispec-selector version=9.4


### PR DESCRIPTION
In Python container, I need to maintain the latest minimal container manually instead of via distgen (until I find a way how to do it in distgen) and because distgen runs also in the CI, I need a way to skip it for a specified version.

Successfully tested in https://github.com/sclorg/s2i-python-container/pull/467