### PR TITLE
Move scripts from s2i-core container image to common scripts

### DIFF
--- a/shared-scripts/core/opt/app-root/etc/scl_enable
+++ b/shared-scripts/core/opt/app-root/etc/scl_enable
@@ -1,0 +1,2 @@
+# This file contains automatic SCL enablement.
+unset BASH_ENV PROMPT_COMMAND ENV

--- a/shared-scripts/core/usr/bin/base-usage
+++ b/shared-scripts/core/usr/bin/base-usage
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+cat <<EOF
+This image serves as the base image for all OpenShift v3 S2I builder images.
+It provides all essential libraries and development tools needed to
+successfully build and run an application.
+
+To use this image as a base image, you need to have 's2i/bin' directory in the
+same directory as your S2I image Dockerfile. This directory should contain S2I
+scripts.
+
+This base image also provides the default user you should use to run your
+application. Your Dockerfile should include this instruction after you finish
+installing software:
+
+USER default
+
+The default directory for installing your application sources is
+'/opt/app-root/src' and the WORKDIR and HOME for the 'default' user is set
+to this directory as well. In your S2I scripts, you don't have to use absolute
+path, but rather rely on the relative path.
+
+To learn more about S2I visit: https://github.com/openshift/source-to-image
+EOF

--- a/shared-scripts/core/usr/bin/base-usage
+++ b/shared-scripts/core/usr/bin/base-usage
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 cat <<EOF
-This image serves as the base image for all OpenShift v3 S2I builder images.
+This image serves as the base image for all OpenShift S2I builder images.
 It provides all essential libraries and development tools needed to
 successfully build and run an application.
 

--- a/shared-scripts/core/usr/bin/cgroup-limits
+++ b/shared-scripts/core/usr/bin/cgroup-limits
@@ -1,0 +1,102 @@
+#!/usr/libexec/platform-python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes for cgroups v1
+        and from /sys/fs/cgroup/memory.max for cgroups v2
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus for cgroups v1
+        and from /sys/fs/cgroup/cpuset.cpus.effective for cgroups v2
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    # If first file does not exist, try cgroups v2 file
+    limit = limit or _read_file('/sys/fs/cgroup/memory.max')
+    if limit is None or not limit.isdigit():
+        if limit == 'max':
+            return 9223372036854775807
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    # If first file does not exist, try cgroups v2 file
+    line = line or _read_file('/sys/fs/cgroup/cpuset.cpus.effective')
+    if line is None:
+        # None of the files above exists when running podman as non-root,
+        # so in that case, this warning is printed every-time
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/shared-scripts/core/usr/bin/container-entrypoint
+++ b/shared-scripts/core/usr/bin/container-entrypoint
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$@"

--- a/shared-scripts/core/usr/bin/fix-permissions
+++ b/shared-scripts/core/usr/bin/fix-permissions
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Allow this script to fail without failing a build
+set +e
+
+SYMLINK_OPT=${2:--L}
+
+# Fix permissions on the given directory or file to allow group read/write of
+# regular files and execute of directories.
+
+[ $(id -u) -ne 0 ] && CHECK_OWNER=" -uid $(id -u)"
+
+# If argument does not exist, script will still exit with 0,
+# but at least we'll see something went wrong in the log
+if ! [ -e "$1" ] ; then
+  echo "ERROR: File or directory $1 does not exist." >&2
+  # We still want to end successfully
+  exit 0
+fi
+
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} \! -gid 0 -exec chgrp 0 {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} \! -perm -g+rw -exec chmod g+rw {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} -perm /u+x -a \! -perm /g+x -exec chmod g+x {} +
+find $SYMLINK_OPT "$1" ${CHECK_OWNER} -type d \! -perm /g+x -exec chmod g+x {} +
+
+# Always end successfully
+exit 0

--- a/shared-scripts/core/usr/bin/prepare-yum-repositories
+++ b/shared-scripts/core/usr/bin/prepare-yum-repositories
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This script is used to prepare yum repositories, that are given as arguments.
+# It is no-op if user also mounts the repo file(s) into the container during
+# image build.  This can be done by one of those commands:
+#
+#   docker build -v /some/repo/file:/etc/yum.repos.d/sclorg_custom.repo
+#   docker build -v /some/repo/directory:/etc/yum.repos.d
+#   make CUSTOM_REPO=/some/repo/file/or/directory
+#
+# The last one works for projects where we have Makefile with the
+# container-common-scripts support.
+
+set -ex
+
+# DEFAULT_REPOS and SKIP_REPOS_{ENABLE,DISABLE} are intentionally undocumented,
+# but might be used if we need to change this behaviour.
+# Once we realize there are real use cases for using those variables, we should
+# document them properly.
+DEFAULT_REPOS=${DEFAULT_REPOS:-"rhel-7-server-rpms rhel-7-server-optional-rpms"}
+SKIP_REPOS_ENABLE=${SKIP_REPOS_ENABLE:-false}
+SKIP_REPOS_DISABLE=${SKIP_REPOS_DISABLE:-false}
+
+function is_subscribed() {
+  for f in /run/secrets/etc-pki-entitlement/*.pem ; do
+    [ -e "$f" ] && return 0
+    break
+  done
+  return 1
+}
+
+# DEBUGGING CASE!  Mostly for 'make CUSTOM_REPO=/some/file/or/dir'.
+test ! -f /etc/yum.repos.d/sclorg_custom.repo && \
+! mountpoint /etc/yum.repos.d \
+    || exit 0
+
+# install yum-utils for yum-config-manager
+yum install -y yum-utils
+
+if [ "$SKIP_REPOS_DISABLE" = false ] && is_subscribed; then
+  # Disable only repos that might come from subscribed host, because there
+  # might be other repos provided by user or build system
+
+  disable_repos=
+  # Lines look like: "Repo-id  :  dist-tag-override/x86_64"
+  while IFS=' /' read -r _ _ repo_id _; do
+      case $repo_id in rhel-*)
+        disable_repos+=" $repo_id" ;;
+      esac
+  done <<<"$(yum repolist -v 2>/dev/null | grep Repo-id)"
+
+  if test -n "$disable_repos"; then
+    yum-config-manager --disable $disable_repos &> /dev/null
+  fi
+fi
+
+if [ ${SKIP_REPOS_ENABLE} = false ] && [ -n "${DEFAULT_REPOS}" -o $# -gt 0 ] ; then
+  yum-config-manager --enable ${DEFAULT_REPOS} "$@"
+fi

--- a/shared-scripts/core/usr/bin/rpm-file-permissions
+++ b/shared-scripts/core/usr/bin/rpm-file-permissions
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+CHECK_DIRS="/ /opt /etc /usr /usr/bin /usr/lib /usr/lib64 /usr/share /usr/libexec"
+
+rpm_format="[%{FILESTATES:fstate}  %7{FILEMODES:octal} %{FILENAMES:shescape}\n]"
+
+rpm -q --qf "$rpm_format" filesystem | while read line
+do
+    eval "set -- $line"
+
+    case $1 in
+        normal) ;;
+        *) continue ;;
+    esac
+
+    case " $CHECK_DIRS " in
+        *" $3 "*)
+            chmod "${2: -4}" "$3"
+            ;;
+    esac
+done


### PR DESCRIPTION
This change is important for minimal containers because they are
not based on s2i-core/s2i-base but still need some of the scripts.
This way, we can still maintain them in one place and copy them
to whatever image we need.

Related to: https://github.com/sclorg/s2i-python-container/pull/467 Has to be merged together with: https://github.com/sclorg/s2i-base-container/pull/215