### PR TITLE
Do not install pre-commit hooks automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ shellcheck:
 	./run-shellcheck.sh `git ls-files *.sh`
 
 pre-commit-check:
-	pre-commit install
 	pre-commit run --all
+	[[ -d "./.git/hooks" && -n `find ./.git/hooks/ -name "pre-commit"` ]] || \
+	  echo "Note: Install pre-commit hooks by 'pre-commit install' and you'll never have to run this check manually again."
 
 check-failures: check-test-lib
 	cd tests/failures/check && make tag && ! make check && make clean


### PR DESCRIPTION
We have agreed on today's meeting that `make pre-commit-check` should not install pre-commit hooks into a local dev git repository. Installing them is an unexpected and possibly unwanted side-effect that is not needed for a one-time check run.

Instead, I've implemented a simple check whether they are already installed or not, and if not, there is a note about how to install them to run the check automatically before every commit.