### PR TITLE
Support testing in CVP

### DIFF
--- a/betka.sh
+++ b/betka.sh
@@ -8,7 +8,8 @@
 set -ex
 
 function load_configuration() {
-  if [[ x"${OS}" == "xfedora" ]]; then
+  # shellcheck disable=SC2268
+  if [[ x"$OS" == "xfedora" ]]; then
     HTTP_CODE=$(curl --output cwt_config --silent --write-out "%{http_code}" -L https://raw.githubusercontent.com/sclorg/container-workflow-tool/master/cwt_generator.config)
     if [[ ${HTTP_CODE} == 404 ]]; then
       exit 1

--- a/build.sh
+++ b/build.sh
@@ -92,7 +92,7 @@ function pull_image {
     image_name=$(echo "$line" | cut -d ' ' -f2)
 
     # In case FROM scratch is defined, skip it
-    if [[ x"$image_name" == "xscratch" ]]; then
+    if [[ "$image_name" == "scratch" ]]; then
       continue
     fi
     echo "-> Pulling image $image_name before building image from $dockerfile."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -342,7 +342,7 @@ function _ct_os_get_uniq_project_name() {
 # to authenticate to image registries.
 # shellcheck disable=SC2120
 function ct_os_new_project() {
-  if [ "${CVP:-0}" -eq 1 ]; then
+  if [ "${CVP:-0}" -eq "1" ]; then
     echo "Testing in CVP environment. No need to create OpenShift project. This is done by CVP pipeline"
     return
   fi
@@ -368,7 +368,7 @@ function ct_os_new_project() {
 # Arguments: project - project name, uses the current project if omitted
 # shellcheck disable=SC2120
 function ct_os_delete_project() {
-  if [ "${CT_SKIP_NEW_PROJECT:-false}" == 'true' ] || [ "${CVP:-0}" -eq 1 ]; then
+  if [ "${CT_SKIP_NEW_PROJECT:-false}" == 'true' ] || [ "${CVP:-0}" -eq "1" ]; then
     echo "Deleting project skipped, cleaning objects only."
     # when not having enough privileges (remote cluster), it might fail and
     # it is not a big problem, so ignore failure in this case
@@ -669,7 +669,7 @@ function ct_os_test_s2i_app_func() {
   namespace=${CT_NAMESPACE:-"$(oc project -q)"}
   local image_tagged="${image_name_no_namespace%:*}:${VERSION}"
 
-  if [ "${CVP:-0}" -eq 0 ]; then
+  if [ "${CVP:-0}" -eq "0" ]; then
     if [ "${CT_EXTERNAL_REGISTRY:-false}" == 'true' ] ; then
       ct_os_import_image_ocp4 "${image_name}" "${image_tagged}"
     else
@@ -812,8 +812,7 @@ function ct_os_test_template_app_func() {
 
   namespace=${CT_NAMESPACE:-"$(oc project -q)"}
   # Upload main image is already done by CVP pipeline. No need to do it twice.
-  # shellcheck disable=SC2086
-  if [ ${CVP:-0} -eq 0 ]; then
+  if [ "${CVP:-0}" -eq "0" ]; then
     # Create a specific imagestream tag for the image so that oc cannot use anything else
     if [ "${CT_EXTERNAL_REGISTRY:-false}" == 'true' ] ; then
       ct_os_import_image_ocp4 "${image_name}" "${image_tagged}"
@@ -1058,7 +1057,7 @@ ct_os_test_response_internal() {
   local status
   local response_code
   local response_file
-  local util_image_name='ubi7/ubi'
+  local util_image_name='registry.access.redhat.com/ubi7/ubi'
 
   response_file=$(mktemp /tmp/ct_test_response_XXXXXX)
   ct_os_deploy_cmd_image "${util_image_name}"

--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -47,7 +47,7 @@ function ct_os_set_path_oc_4() {
 #
 #
 function ct_os_set_ocp4() {
-  if [ "${CVP:-0}" -eq 1 ]; then
+  if [ "${CVP:-0}" -eq "1" ]; then
     echo "Testing in CVP environment. No need to login to OpenShift cluster. This is already done by CVP pipeline."
     return
   fi

--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -47,6 +47,10 @@ function ct_os_set_path_oc_4() {
 #
 #
 function ct_os_set_ocp4() {
+  if [ "${CVP:-0}" -eq 1 ]; then
+    echo "Testing in CVP environment. No need to login to OpenShift cluster. This is already done by CVP pipeline."
+    return
+  fi
   local login
   OS_OC_CLIENT_VERSION=${OS_OC_CLIENT_VERSION:-4.4}
   ct_os_set_path_oc_4 "${OS_OC_CLIENT_VERSION}"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -583,13 +583,13 @@ ct_get_public_image_name() {
   local registry
 
   registry=$(ct_registry_from_os "$os")
-  if [ "x$os" == "xrhel7" ]; then
+  if [ "$os" == "rhel7" ]; then
     public_image_name=$registry/rhscl/$base_image_name-${version//./}-rhel7
-  elif [ "x$os" == "xrhel8" ]; then
+  elif [ "$os" == "rhel8" ]; then
     public_image_name=$registry/rhel8/$base_image_name-${version//./}
-  elif [ "x$os" == "xcentos7" ]; then
+  elif [ "$os" == "centos7" ]; then
     public_image_name=$registry/centos7/$base_image_name-${version//./}-centos7
-  elif [ "x$os" == "xcentos8" ]; then
+  elif [ "$os" == "centos8" ]; then
     public_image_name=$registry/centos8/$base_image_name-${version//./}-centos8
   fi
 

--- a/test-openshift.yaml
+++ b/test-openshift.yaml
@@ -1,0 +1,71 @@
+---
+  ###
+  #
+  # This playbook is used for testing SCLORG images in OpenShift 4
+  # by Container Verification Pipeline (CVP).
+  #
+  #
+  # The Ansible log created when this playbook is run is archived by CVP as an artifact.
+  #
+  ###
+- hosts: all # At runtime this playbook will be executed on a Jenkins slave against 'localhost'
+  gather_facts: false
+  tags:
+    - openshift
+
+  # Here's an example of setting environment vars that will be picked up by
+  # the runtest.sh shell script below.
+  environment:
+    VERSION: VERSION_NUMBER
+    OS: OS_NUMBER
+    IMAGE_FULL_NAME: "{{ image_full_name }}"
+    IMAGE_REGISTRY_URL: "{{ image_registry_url }}"
+    IMAGE_NAMESPACE: "{{ image_namespace }}"
+    IMAGE_NAME: "{{ image_name }}"
+    IMAGE_TAG: "{{ image_tag }}"
+    IMAGE_DIGEST: "{{ image_digest }}"
+    OPENSHIFT_CLUSTER_URL: "{{ openshift_cluster_url }}"
+    OPENSHIFT_AUTH_TOKEN: "{{ openshift_auth_token }}"
+    OPENSHIFT_USERNAME: "{{ openshift_username }}"
+    OPENSHIFT_PROJECT_NAME: "{{ openshift_project_name }}"
+    CVP_ARTIFACTS_DIR: "{{ cvp_artifacts_dir }}"
+
+  tasks:
+    # CVP should have created the artifacts directory already, but it's always good to check.
+    - name: "Make sure the artifacts directory exists"
+      file:
+        path: "{{ cvp_artifacts_dir }}"
+        state: directory
+
+    # This block is an example of a solely Ansible approach to test a container image in OpenShift.
+    # It demonstrates how to interact with the unique 'sandbox' project created by CVP in OpenShift
+    # to import, run, and interact with your container image.
+    - name: "Run sclorg image name tests in OpenShift 4 environment."
+      block:
+        # Log into the cluster where CVP is running
+        - name: Log into the OpenShift cluster
+          shell: oc login {{ openshift_cluster_url }} --token="{{ openshift_auth_token }}" --insecure-skip-tls-verify
+
+        # Connect to the newly-created temporary 'sandbox' project in OpenShift to run your tests
+        - name: Select the project {{ openshift_project_name }}
+          shell: oc project {{ openshift_project_name }}
+
+        - name: Import the image into OpenShift
+          shell: oc import-image {{ image_name }} --from={{ image_full_name }} --insecure=true --confirm
+          retries: 3
+          delay: 10
+
+        # Derive fully qualified image name of your newly imported image for the next step
+        - name: Get imported image registry URL
+          shell: oc get is {{ image_name }} --output=jsonpath='{ .status.dockerImageRepository }'
+          register: imported_image_url
+
+        # Ensure that we can access the /apis/config.openshift.io/v1/clusterversions/version endpoint on OCP4.x
+        - name: Test the version command on v4.x
+          shell: oc get clusterversions
+          register: oc_version_cmd
+          when: openshift_cluster_version == "v4.x"
+
+        # Run tests on OpenShift 4
+        - name: Run a sclorg test suite in OpenShift 4
+          shell: VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash test/run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,7 @@ for dir in ${VERSIONS}; do
   IMAGE_VERSION=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
   # Kept also IMAGE_NAME as some tests might still use that.
   IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$IMAGE_VERSION"
+    # shellcheck disable=SC2268
   if [ x"${OS}" == "xcentos7" ]; then
     export IMAGE_NAME="$REGISTRY$IMAGE_NAME"
   else


### PR DESCRIPTION
This pull request adds support for testing our containers in CVP pipeline.

The new variable is defined called `CVP=1`.
The test alone is executed from test/test-openshift.yaml playbook if file test/run-openshift-remote-cluster exists.

We will NOT create a project. This is already done by CVP.

The parameters to the script are:
```
VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash test/run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log
```

We do NOT build the image itself. It is provided and already uploaded into OCP4 cluster by CVP. Therefore it is specified as a parameter into `test/run-openshift-remote-cluster` script. The same as VERSION and OS.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>