### PR TITLE
Do not exit in case of container failed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,7 @@ check-latest-imagestream:
 check-betka:
 	cd tests && ./check_betka.sh
 
-check: check-failures check-squash check-latest-imagestream
+check-remote-containers:
 	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh
+
+check: check-failures check-squash check-latest-imagestream check-remote-containers


### PR DESCRIPTION
This commit brings a new functionality
into testing container-common-scripts.
It does not exit in case one of defined
containers failed but continue into the next.
At the end is shown message, what containers
failed.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>