### PR TITLE
Fixes: #195 turn of set +e while 'oc cluster down'

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -530,8 +530,9 @@ function ct_os_cluster_up() {
 # Shuts down the local OpenShift cluster using 'oc cluster down'
 function ct_os_cluster_down() {
   if [ ${OS_CLUSTER_STARTED_BY_TEST:-0} -eq 1 ] ; then
-    echo "Cluster started by the test, shutting down."
+    echo "Switching user to system:admin before cluster is going down."
     oc login -u system:admin
+    echo "Cluster started by the test, shutting down."
     oc cluster down
   else
     echo "Cluster not started by the test, shutting down skipped."

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -531,6 +531,7 @@ function ct_os_cluster_up() {
 function ct_os_cluster_down() {
   if [ ${OS_CLUSTER_STARTED_BY_TEST:-0} -eq 1 ] ; then
     echo "Cluster started by the test, shutting down."
+    oc login -u system:admin
     oc cluster down
   else
     echo "Cluster not started by the test, shutting down skipped."


### PR DESCRIPTION
Turn of 'set +e' while oc cluster down and
switch user to system:admin

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>