### PR TITLE
Fix ct_pull_image. The fourth parameter is not used at all

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -61,9 +61,9 @@ function ct_enable_cleanup() {
 # Function returns either 0 in case of pull was successful
 # Or the test suite exit with 1 in case of pull error
 function ct_pull_image() {
-  local image_name="$1"; shift
-  local exit=${1:-"false"}; shift
-  local loops=${1:-10}; shift
+  local image_name="$1"; [[ $# -gt 0 ]] && shift
+  local exit_variable=${1:-"false"}; [[ $# -gt 0 ]] && shift
+  local loops=${1:-10}
   local loop=0
 
   # Let's try to pull image.
@@ -84,7 +84,7 @@ function ct_pull_image() {
       echo "Pulling of image $image_name failed $loops times in a row. Giving up."
       echo "!!! ERROR with pulling image $image_name !!!!"
       # shellcheck disable=SC2268
-      if [[ x"$exit" == x"false" ]]; then
+      if [[ x"$exit_variable" == x"false" ]]; then
         return 1
       else
         exit 1


### PR DESCRIPTION
`ct_pull_image <image> <true|false> <count>`
count is optional.

Fourth parameter is not used at all.
When the bash is trying to shift, then it failed with exit 1.
```bash
VERSIONS="2.7 3.6 3.8 3.9 3.9-minimal" BASE_IMAGE_NAME="python" SKIP_SQUASH=0 UPDATE_BASE= OS=rhel7 CLEAN_AFTER= DOCKER_BUILD_CONTEXT=.. OPENSHIFT_NAMESPACES="" CUSTOM_REPO="" REGISTRY="""" TEST_OPENSHIFT_4=true /usr/bin/env bash common/test.sh
make: *** [test-openshift-4] Error 1
```

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>