### PR TITLE
Fix ct_os_test_image_update

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -957,8 +957,9 @@ ct_os_test_image_update() {
   local old_image=$1; shift
   local istag=$1; shift
   local check_function=$1; shift
-  local service_name=${image_name##*/}
   local ip="" check_command_exp=""
+  local image_name_no_namespace=${image_name##*/}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   echo "Running image update test for: $image_name"
   # shellcheck disable=SC2119


### PR DESCRIPTION
Service name has a wrong name:
oc new-app php:7.3~https://github.com/sclorg/s2i-php-container.git --context-dir=7.3/test/test-app --name php-73-centos7:7.3

And --name should be php-73-centos7-testing

The function itself is used only here:
https://github.com/search?q=org%3Asclorg+ct_os_test_image_update&type=code

And nowadays only here: https://github.com/search?q=org%3Asclorg+ct_os_test_image_update&type=code
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>