### PR TITLE
Add support for testing CentOS Stream 9

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ for dir in ${VERSIONS}; do
   # Kept also IMAGE_NAME as some tests might still use that.
   IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$IMAGE_VERSION"
     # shellcheck disable=SC2268
-  if [ x"${OS}" == "xcentos7" ]; then
+  if [ "${OS}" == "centos7" ] || [ "${OS}" == "c9s" ]; then
     export IMAGE_NAME="$REGISTRY$IMAGE_NAME"
   else
     export IMAGE_NAME


### PR DESCRIPTION
Testing c9s are now supported.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>