### PR TITLE
exit on cleanup for openshift remote cluster

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -17,9 +17,11 @@ function ct_os_cleanup() {
   if [ $TESTSUITE_RESULT -eq 0 ] ; then
     # shellcheck disable=SC2153
     echo "OpenShift tests for ${IMAGE_NAME} succeeded."
+    exit 0
   else
     # shellcheck disable=SC2153
     echo "OpenShift tests for ${IMAGE_NAME} failed."
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Till this moment stopping of the openshift test suite was done with `exit -e`, when the user typed ctrl-c.
This approach is changing, because if `set -e` is used the whole test suite fails on the first failed test.

This means that `ct_os_cleanup` function should be able to **gracefully(?)**  clean up the resources and exit the testing.

The only use case, where `ct_os_cleanup` is used is for the `trap` builtin, reacting to EXIT and SIGINT. In both cases the added `exit`s should not cause any harm.

I am not really sure about the approach I proposed with this PR, but I did not find any better one. If you see some better solution, please propose it.