### PR TITLE
change the info log function to echo, as it is not available in the test-lib.sh

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1083,7 +1083,7 @@ ct_run_tests_from_testset() {
   local app_name="$1"
   for test_case in $TEST_SET; do
     TESTCASE_RESULT=0
-    info "Running test $test_case ... "
+    echo "Running test $test_case ... "
     $test_case
     ct_check_testcase_result $?
     local test_msg


### PR DESCRIPTION
This fixes the following error(if you have info command installed in your system):
`info: No menu item 'Running test test_perl_imagestream ... ' in node '(dir)Top'`