### PR TITLE
Print 'oc version' and check client version after login

### DIFF
--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -31,13 +31,6 @@ function ct_os_set_path_oc_4() {
        return 1
     fi
     export PATH="${oc_path}:${PATH}"
-    oc version
-    if ! oc version | grep -q "Client Version: ${oc_version}." ; then
-        echo "ERROR: something went wrong, oc located at ${oc_path}, but oc of version ${oc_version} not found in PATH ($PATH)" >&1
-        return 1
-    else
-        echo "PATH set correctly, binary oc found in version ${oc_version}: $(command -v oc)"
-    fi
 }
 
 # ct_os_prepare_ocp4
@@ -54,10 +47,15 @@ function ct_os_set_ocp4() {
   OS_OC_CLIENT_VERSION=${OS_OC_CLIENT_VERSION:-4.4}
   ct_os_set_path_oc_4 "${OS_OC_CLIENT_VERSION}"
 
-  oc version
-
   login=$(cat "$KUBEPASSWORD")
   oc login -u kubeadmin -p "$login"
+  oc version
+  if ! oc version | grep -q "Client Version: ${OS_OC_CLIENT_VERSION}." ; then
+    echo "ERROR: something went wrong, oc located at ${oc_path}, but oc of version ${OS_OC_CLIENT_VERSION} not found in PATH ($PATH)" >&1
+    return 1
+  else
+    echo "PATH set correctly, binary oc found in version ${OS_OC_CLIENT_VERSION}: $(command -v oc)"
+  fi
   echo "Login to OpenShift ${OS_OC_CLIENT_VERSION} is DONE"
   # let openshift cluster to sync to avoid some race condition errors
   sleep 3


### PR DESCRIPTION
This commit fixes issue caused by checking `oc version` before oc login.

Before this fix, we see output like:
```bash
PATH /usr/local/oc-v4.4/bin
Binary oc found in /usr/local/oc-v4.4/bin
Client Version: 4.4.0-0.nightly-2020-06-01-021027
error: You must be logged in to the server (Unauthorized)
OpenShift tests for ubi8/nodejs-12:1 failed.
make: *** [common/common.mk:103: test-openshift-4] Error 1
```

after a fix the output looks like:
```bash
PATH /usr/local/oc-v4.4/bin
Binary oc found in /usr/local/oc-v4.4/bin
Login successful.

You have access to 67 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
Client Version: 4.4.0-0.nightly-2020-06-01-021027
Server Version: 4.10.3
Kubernetes Version: v1.23.3+e419edf
PATH set correctly, binary oc found in version 4.4: /usr/local/oc-v4.4/bin/oc
Login to OpenShift 4.4 is DONE
```
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>