### PR TITLE
Improve log debug

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -49,6 +49,24 @@ function ct_cleanup() {
   done
   rmdir "$CID_FILE_DIR"
   : "Done."
+
+  ct_show_results
+  exit $TESTCASE_RESULT
+}
+
+# ct_show_results
+# ---------------
+# Prints results of all test cases that are stored into TEST_SUMMARY variable.
+# Uses: $TEST_SUMMARY - text info about test-cases
+# Uses: $TESTCASE_RESULT - overall result of all tests
+function ct_show_results() {
+  echo "$TEST_SUMMARY"
+
+  if [ $TESTSUITE_RESULT -eq 0 ] ; then
+    echo "Tests for ${IMAGE_NAME} succeeded."
+  else
+    echo "Tests for ${IMAGE_NAME} failed."
+  fi
 }
 
 # ct_enable_cleanup
@@ -1118,14 +1136,14 @@ ct_run_tests_from_testset() {
 # ct_timestamp_s
 # --------------
 # Returns timestamp in seconds
-ct_timestamp_s() {
+function ct_timestamp_s() {
   date '+%s'
 }
 
 # ct_timestamp_pretty
 # -----------------
 # Returns timestamp readable to a human
-ct_timestamp_pretty() {
+function ct_timestamp_pretty() {
   date --rfc-3339=seconds
 }
 
@@ -1135,7 +1153,7 @@ ct_timestamp_pretty() {
 # Argument: start_date - Beginning (in seconds)
 # Argument: final_date - End (in seconds)
 # Returns: Time difference in format HH:MM:SS
-ct_timestamp_diff() {
+function ct_timestamp_diff() {
   local start_date=$1
   local final_date=$1
   date -u -d "0 $final_date seconds - $start_date seconds" +"%H:%M:%S"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -951,6 +951,7 @@ ct_check_latest_imagestreams() {
 # Prints the available resources
 ct_show_resources()
 {
+  echo
   echo "Resources info:"
   echo "Memory:"
   free -h
@@ -1119,7 +1120,11 @@ ct_run_tests_from_testset() {
   local test_msg
 
   # Let's store in the log what change do we test
+  echo
   git show
+  echo
+  echo "Test cases results:"
+  echo
 
   for test_case in $TEST_SET; do
     TESTCASE_RESULT=0

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1125,7 +1125,7 @@ ct_run_tests_from_testset() {
 
   # Let's store in the log what change do we test
   echo
-  git show
+  git show --no-patch
   echo
 
   for test_case in $TEST_SET; do

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1110,7 +1110,7 @@ ct_run_tests_from_testset() {
       TESTSUITE_RESULT=1
     fi
     local time_diff=$(ct_timestamp_diff "$time_beg" "$time_end")
-    printf -v TEST_SUMMARY "%s %s for '%s' %s (%s)\n" "${TEST_SUMMARY}" "${test_msg}" "${app_name}" "$test_case" "$time_diff"
+    printf -v TEST_SUMMARY "%s %s for '%s' %s (%s)\n" "${TEST_SUMMARY:-}" "${test_msg}" "${app_name}" "$test_case" "$time_diff"
     [ -n "${FAIL_QUICKLY:-}" ] && return 1
   done;
 }

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -60,6 +60,10 @@ function ct_cleanup() {
 # Uses: $TEST_SUMMARY - text info about test-cases
 # Uses: $TESTCASE_RESULT - overall result of all tests
 function ct_show_results() {
+  echo
+  echo "==============================================="
+  echo "Test cases results:"
+  echo
   echo "${TEST_SUMMARY:-}"
 
   if [ -n "${TESTSUITE_RESULT:-}" ] ; then
@@ -1123,14 +1127,14 @@ ct_run_tests_from_testset() {
   echo
   git show
   echo
-  echo "Test cases results:"
-  echo
 
   for test_case in $TEST_SET; do
     TESTCASE_RESULT=0
     time_beg_pretty=$(ct_timestamp_pretty)
     time_beg=$(ct_timestamp_s)
+    echo "-----------------------------------------------"
     echo "Running test $test_case (starting at $time_beg_pretty) ... "
+    echo "-----------------------------------------------"
     $test_case
     ct_check_testcase_result $?
     time_end=$(ct_timestamp_s)

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1089,7 +1089,7 @@ ct_check_testcase_result() {
 # Uses: $TEST_SUMMARY - variable for storing test results
 # Uses: $IMAGE_NAME - name of the image being tested
 ct_run_tests_from_testset() {
-  local app_name="$1"
+  local app_name="${1:-appnamenotset}"
 
   # Let's store in the log what change do we test
   git show

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1155,7 +1155,7 @@ function ct_timestamp_pretty() {
 # Returns: Time difference in format HH:MM:SS
 function ct_timestamp_diff() {
   local start_date=$1
-  local final_date=$1
+  local final_date=$2
   date -u -d "0 $final_date seconds - $start_date seconds" +"%H:%M:%S"
 }
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1152,14 +1152,14 @@ ct_run_tests_from_testset() {
 
 # ct_timestamp_s
 # --------------
-# Returns timestamp in seconds
+# Returns timestamp in seconds since unix era -- a large integer
 function ct_timestamp_s() {
   date '+%s'
 }
 
 # ct_timestamp_pretty
 # -----------------
-# Returns timestamp readable to a human
+# Returns timestamp readable to a human, like 2022-05-18 10:52:44+02:00
 function ct_timestamp_pretty() {
   date --rfc-3339=seconds
 }
@@ -1167,8 +1167,8 @@ function ct_timestamp_pretty() {
 # ct_timestamp_diff
 # -----------------
 # Computes a time diff between two timestamps
-# Argument: start_date - Beginning (in seconds)
-# Argument: final_date - End (in seconds)
+# Argument: start_date - Beginning (in seconds since unix era -- a large integer)
+# Argument: final_date - End (in seconds since unix era -- a large integer)
 # Returns: Time difference in format HH:MM:SS
 function ct_timestamp_diff() {
   local start_date=$1


### PR DESCRIPTION
By including timestamp, test duration, and a bit more separators in the test log, it should be easier to debug tests and read longer logs.