### PR TITLE
force image removal during cleanup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ function clean_image {
       previous_id=$(cat .image-id.raw)
       if test "$IMAGE_ID" != "$previous_id"; then
           # Also remove squashed image since it will change anyway
-          docker rmi "$previous_id" "$(cat .image-id)" || :
+          docker rmi --force "$previous_id" "$(cat .image-id)" || :
           rm -f ".image-id.raw" ".image-id" || :
       fi
   fi

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -36,7 +36,7 @@ function ct_cleanup() {
     docker stop "$container"
 
     # Container has not been removed by `docker stop` and still exists
-    if [ $( docker ps -a -f id=$container | wc -l ) -eq 2 ]; then
+    if [ "$( docker ps -a -f "id=$container" | wc -l )" -eq 2 ]; then
       exit_status=$(docker inspect -f '{{.State.ExitCode}}' "$container")
       if [ "$exit_status" != "$EXPECTED_EXIT_CODE" ]; then
         : "Dumping logs for $container"


### PR DESCRIPTION
podman will complain if we try to remove an image by ID when it has multiple tags
We are always using mulitple tags, so we need to force the removal