### PR TITLE
Print out docker logs if the container test failed.

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1051,6 +1051,8 @@ ct_test_app_dockerfile() {
   ct_test_response "http://$ip:${port}" 200 "${expected_text}"
   ret=$?
 
+  [[ $ret -eq 0 ]] || docker logs "$(ct_get_cid "${cname}")"
+
   # cleanup
   docker kill "$(ct_get_cid "${cname}")"
   sleep 2


### PR DESCRIPTION
Print out docker logs if the container test failed.