### PR TITLE
Fix for 'ct_doc_content_old' and grep

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -291,7 +291,7 @@ function ct_doc_content_old() {
     docker run --rm "${IMAGE_NAME}" /bin/bash -c "cat /${f}" >"${tmpdir}/$(basename "${f}")"
     # Check whether the files contain some important information
     for term in "$@" ; do
-      if ! grep -F -q -e "${term}" "${tmpdir}/$(basename "${f}")" ; then
+      if ! grep -E -q -e "${term}" "${tmpdir}/$(basename "${f}")" ; then
         echo "ERROR: File /${f} does not include '${term}'." >&2
         return 1
       fi


### PR DESCRIPTION
This causes problems in Fedora hosts systems. See the error here: https://artifacts.dev.testing-farm.io/d0a22c42-da90-43bf-9523-786a274e68ee

```bash
ERROR: File /help.1 does not include 'MYSQL\_ROOT\_PASSWORD'.
```

The function is now used only in two containers: `mariadb-container` and `mysql-container`.
postgresql-container solve it by own way https://github.com/sclorg/postgresql-container/blob/master/test/run_test#L694

Changing the `grep -F` to `grep -E` solves the issue.

From `man grep`:
```bash
   Pattern Syntax
       -E, --extended-regexp
              Interpret PATTERNS as extended regular expressions (EREs, see below).

       -F, --fixed-strings
              Interpret PATTERNS as fixed strings, not regular expressions.

   Matching Control
       -e PATTERNS, --regexp=PATTERNS
              Use  PATTERNS  as  the patterns.  If this option is used multiple times or is combined with the -f (--file) option, search for all patterns given.
              This option can be used to protect a pattern beginning with “-”.
```

Option `-F` is against `-e`.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>