### PR TITLE
Print status on cleanup for containers

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -25,6 +25,9 @@ export TESTSUITE_RESULT=0
 # unexpectedly. Removes the cid_files and CID_FILE_DIR as well.
 # Uses: $CID_FILE_DIR - path to directory containing cid_files
 # Uses: $EXPECTED_EXIT_CODE - expected container exit code
+# Uses: $TEST_SUMMARY - all run tests logged and marked PASSED/FAILED
+# Uses: $TESTSUITE_RESULT - 0 if all tests passed, 1 otherwise
+# Uses: $IMAGE_NAME - name of tested image
 function ct_cleanup() {
   ct_show_resources
   for cid_file in "$CID_FILE_DIR"/* ; do
@@ -49,6 +52,15 @@ function ct_cleanup() {
   done
   rmdir "$CID_FILE_DIR"
   : "Done."
+  # print stats and exit accordingly
+  echo ${TEST_SUMMARY:-}
+  if [ $TESTSUITE_RESULT -eq 0 ] ; then
+    echo "Container tests for ${IMAGE_NAME} succeeded."
+    exit 0
+  else
+    echo "Container tests for ${IMAGE_NAME} failed."
+    exit 1
+  fi
 }
 
 # ct_enable_cleanup


### PR DESCRIPTION
This adds support for https://github.com/sclorg/s2i-python-container/pull/515.

This PR proposes printing test results on `ct_cleanup`, so the container tests can also use `ct_run_tests_from_testset`.
This PR should not affect containers that yet do not support the `ct_run_tests_from_testset` function, as in that case nothing is printed.

This PR also proposes to exit the shell at the end of the cleanup, so that the user can terminate the test suite manually when `ct_enable_cleanup` is called before.

If the reviewer thinks, this should be separated into two commits I understand and will do it.