### PR TITLE
Add  function to show tags overview in the imagestreams

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1366,4 +1366,19 @@ function ct_os_service_image_info() {
   # so if the specified namespace does not succeed, try the current namespace
   oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml || oc get isimage "${image_id##*/}" -o yaml
 }
+
+# ct_os_show_all_image_stream_tags IMAGE_STREAM_FILE [ IMAGE_STREAM_FILE ... ]
+# --------------------
+# Shows information about the tags in the image stream files given.
+# Argument: image_stream_file - JSON file with the imagestream definition
+function ct_os_show_all_image_stream_tags () {
+  local file_name
+	while [ $# -gt 0 ] ; do
+		file_name="$1"
+		shift
+		echo "Tags in the image stream $file_name:"
+    cat "$file_name" | jq -r '.spec.tags[] | ("- " + .name + " -> " + .from.name)'
+  done
+}
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -1377,7 +1377,7 @@ function ct_os_show_all_image_stream_tags () {
 		file_name="$1"
 		shift
 		echo "Tags in the image stream $file_name:"
-    cat "$file_name" | jq -r '.spec.tags[] | ("- " + .name + " -> " + .from.name)'
+    jq -r '.spec.tags[] | ("- " + .name + " -> " + .from.name)' "$file_name"
   done
 }
 


### PR DESCRIPTION
It's supposed to be used as simple as this:
```
ct_os_show_all_image_stream_tags imagestreams/*json
Tags in the image stream imagestreams/postgresql-centos.json:
- latest -> 12-el8
- 13-el7 -> quay.io/centos7/postgresql-13-centos7:latest
- 12-el8 -> docker.io/centos/postgresql-12-centos8:latest
- 12-el7 -> quay.io/centos7/postgresql-12-centos7:latest
- 12 -> quay.io/centos7/postgresql-12-centos7:latest
- 10-el8 -> docker.io/centos/postgresql-10-centos8:latest
- 10-el7 -> quay.io/centos7/postgresql-10-centos7:latest
- 10 -> quay.io/centos7/postgresql-10-centos7:latest
Tags in the image stream imagestreams/postgresql-rhel-aarch64.json:
- latest -> 13-el8
- 13-el8 -> registry.redhat.io/rhel8/postgresql-13:latest
- 12-el8 -> registry.redhat.io/rhel8/postgresql-12:latest
- 10-el8 -> registry.redhat.io/rhel8/postgresql-10:latest
Tags in the image stream imagestreams/postgresql-rhel.json:
- latest -> 13-el8
- 13-el8 -> registry.redhat.io/rhel8/postgresql-13:latest
- 13-el7 -> registry.redhat.io/rhscl/postgresql-13-rhel7:latest
- 12-el8 -> registry.redhat.io/rhel8/postgresql-12:latest
- 12-el7 -> registry.redhat.io/rhscl/postgresql-12-rhel7:latest
- 12 -> registry.redhat.io/rhscl/postgresql-12-rhel7:latest
- 10-el8 -> registry.redhat.io/rhel8/postgresql-10:latest
- 10-el7 -> registry.redhat.io/rhscl/postgresql-10-rhel7:latest
- 10 -> registry.redhat.io/rhscl/postgresql-10-rhel7:latest
```