### PR TITLE
Shellcheck fixes in the last PR merged

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1133,7 +1133,8 @@ ct_run_tests_from_testset() {
 
   for test_case in $TEST_SET; do
     TESTCASE_RESULT=0
-    if [[ " ${UNSTABLE_TESTS[@]} " =~ " ${test_case} " ]]; then
+    # shellcheck disable=SC2076
+    if [[ " ${UNSTABLE_TESTS[*]} " =~ " ${test_case} " ]]; then
       is_unstable=1
     else
       is_unstable=0
@@ -1150,7 +1151,7 @@ ct_run_tests_from_testset() {
       test_msg="[PASSED]"
     else
       test_msg="[FAILED]"
-      if [ -z $IGNORE_UNSTABLE_TESTS ] || [ $is_unstable -eq 0 ]; then
+      if [ -z "$IGNORE_UNSTABLE_TESTS" ] || [ $is_unstable -eq 0 ]; then
         TESTSUITE_RESULT=1
       fi
     fi


### PR DESCRIPTION
@zmiklank Pls review, whether the changes do not have an unintentional side-effect (I didn't test the functionality itself, only wanted to make the scripts shellcheck clean again). There is a handy `make shellcheck` call that helps keeping the scripts less error-prone.