### PR TITLE
Fix implementation of unstable tests

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -29,6 +29,7 @@ UNSTABLE_TESTS="${UNSTABLE_TESTS:-""}"
 # unexpectedly. Removes the cid_files and CID_FILE_DIR as well.
 # Uses: $CID_FILE_DIR - path to directory containing cid_files
 # Uses: $EXPECTED_EXIT_CODE - expected container exit code
+# Uses: $TESTSUITE_RESULT - overall result of all tests
 function ct_cleanup() {
   ct_show_resources
   for cid_file in "$CID_FILE_DIR"/* ; do
@@ -55,14 +56,14 @@ function ct_cleanup() {
   : "Done."
 
   ct_show_results
-  exit "${TESTCASE_RESULT:-0}"
+  exit "${TESTSUITE_RESULT:-0}"
 }
 
 # ct_show_results
 # ---------------
 # Prints results of all test cases that are stored into TEST_SUMMARY variable.
 # Uses: $TEST_SUMMARY - text info about test-cases
-# Uses: $TESTCASE_RESULT - overall result of all tests
+# Uses: $TESTSUITE_RESULT - overall result of all tests
 function ct_show_results() {
   echo
   echo "==============================================="

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -18,6 +18,10 @@
 EXPECTED_EXIT_CODE=0
 export TESTSUITE_RESULT=0
 
+# define UNSTABLE_TESTS if not already defined, as this variable
+# is not mandatory for containers
+UNSTABLE_TESTS="${UNSTABLE_TESTS:-""}"
+
 # ct_cleanup
 # --------------------
 # Cleans up containers used during tests. Stops and removes all containers
@@ -1134,7 +1138,7 @@ ct_run_tests_from_testset() {
   for test_case in $TEST_SET; do
     TESTCASE_RESULT=0
     # shellcheck disable=SC2076
-    if [[ " ${UNSTABLE_TESTS[*]} " =~ " ${test_case} " ]]; then
+    if [[ " ${UNSTABLE_TESTS[*]} " =~ " ${app_name} " ]]; then
       is_unstable=1
     else
       is_unstable=0
@@ -1150,8 +1154,10 @@ ct_run_tests_from_testset() {
     if [ $TESTCASE_RESULT -eq 0 ]; then
       test_msg="[PASSED]"
     else
-      test_msg="[FAILED]"
-      if [ -z "$IGNORE_UNSTABLE_TESTS" ] || [ $is_unstable -eq 0 ]; then
+      if [ -n "${IGNORE_UNSTABLE_TESTS:-""}" ] && [ $is_unstable -eq 1 ]; then
+        test_msg="[FAILED][UNSTABLE-IGNORED]"
+      else
+        test_msg="[FAILED]"
         TESTSUITE_RESULT=1
       fi
     fi


### PR DESCRIPTION
A whole application can be unstable (like pipenv-test-app) not a specific test case (like test_application).

Cc: @zmiklank 