### PR TITLE
Use -s for --no-patch so it works on rhel7 correctly

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1128,7 +1128,7 @@ ct_run_tests_from_testset() {
 
   # Let's store in the log what change do we test
   echo
-  git show --no-patch
+  git show -s
   echo
 
   for test_case in $TEST_SET; do


### PR DESCRIPTION
Surprisingly, --no-patch option does not exist in git that is on RHEL-7. It still has the option -s that does the same, so let's use this one, to make it not print warning.