### PR TITLE
Get rid off UPDATE_BASE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,6 @@ the image while building. Useful for building rhel-based images on an unsubscrib
 Be aware that you cannot write to any .repo files used this way inside the image as they
 will be mounted into the image as read-only.
 
-`UPDATE_BASE`
-Set to 1 if you want the build script to always pull the base image when available.
-
 `DOCKER_BUILD_CONTEXT`
 Use this variable in case you want to have a different context for your builds. By default
 the context of the build is the versioned directory the Dockerfiles are contained in.

--- a/build.sh
+++ b/build.sh
@@ -136,9 +136,6 @@ function docker_build_with_version {
 
   git_version=$(git rev-parse --short HEAD)
   BUILD_OPTIONS+=" --label io.openshift.builder-version=\"${git_version}\""
-  if [[ "${UPDATE_BASE}" == "1" ]]; then
-    BUILD_OPTIONS+=" --pull=true"
-  fi
 
   # Add possibility to use a development repo
   #

--- a/common.mk
+++ b/common.mk
@@ -70,7 +70,6 @@ REGISTRY ?= ""
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
-	UPDATE_BASE=$(UPDATE_BASE)                      \
 	OS=$(OS)                                        \
 	CLEAN_AFTER=$(CLEAN_AFTER)                      \
 	DOCKER_BUILD_CONTEXT=$(DOCKER_BUILD_CONTEXT)    \


### PR DESCRIPTION
UPDATE_BASE variable is not needed.
It is replaced by function `pull_image` here: https://github.com/sclorg/container-common-scripts/blob/master/build.sh#L81
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>