### PR TITLE
Separate container tests into alone CI test - part 1

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Set variables for Testing Farm
         id: vars
         run: |
-          api_key=${{ secrets.TF_INTERNAL_API_KEY }}
-          branch="master"
-          tf_scope="private"
-          tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "centos7" ]; then
             api_key=${{ secrets.TF_PUBLIC_API_KEY }}
             branch="main"
@@ -47,6 +43,10 @@ jobs:
               tmt_plan="centos7"
             fi
           else
+            api_key=${{ secrets.TF_INTERNAL_API_KEY }}
+            branch="master"
+            tf_scope="private"
+            tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
             if [ "${{ matrix.os }}" == "rhel7" ]; then
               compose="RHEL-7.9-Released"
               context="RHEL7"

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,37 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - tmt_plan: "fedora"
-            os_test: "fedora"
-            context: "Fedora"
-            compose: "Fedora-latest"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
-          - tmt_plan: "centos7"
-            os_test: "centos7"
-            context: "CentOS7"
-            compose: "CentOS-7"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
-          - tmt_plan: "rhel7-docker"
-            os_test: "rhel7"
-            context: "RHEL7"
-            compose: "RHEL-7.9-Released"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel8-docker"
-            os_test: "rhel8"
-            context: "RHEL8"
-            compose: "RHEL-8.6.0-Nightly"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
+        container-to-test: ["postgresql-container", "s2i-nodejs-container", "s2i-python-container"]
+        os: ["fedora", "centos7", "rhel7", "rhel8", "rhel9"]
 
     if: |
       github.event.issue.pull_request
@@ -54,16 +25,61 @@ jobs:
         with:
           ref: "refs/pull/${{ github.event.issue.number }}/head"
 
+      - name: Set variables for Testing Farm
+        id: vars
+        run: |
+          api_key=${{ secrets.TF_INTERNAL_API_KEY }}
+          branch="master"
+          tf_scope="private"
+          tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "centos7" ]; then
+            api_key=${{ secrets.TF_PUBLIC_API_KEY }}
+            branch="main"
+            tf_scope="public"
+            tmt_repo="https://github.com/sclorg/sclorg-testing-farm"
+            if [ "${{ matrix.os }}" == "fedora" ]; then
+              compose="Fedora-latest"
+              context="Fedora"
+              tmt_plan="fedora"
+            else
+              compose="CentOS-7"
+              context="CentOS7"
+              tmt_plan="centos7"
+            fi
+          else
+            if [ "${{ matrix.os }}" == "rhel7" ]; then
+              compose="RHEL-7.9-Released"
+              context="RHEL7"
+              tmt_plan="rhel7-docker"
+            elif [ "${{ matrix.os }}" == "rhel8" ]; then
+              compose="RHEL-8.6.0-Nightly"
+              context="RHEL8"
+              tmt_plan="rhel8-docker"
+            else
+              compose="RHEL-9.1.0-Nightly"
+              context="RHEL9"
+              tmt_plan="rhel9-docker"
+            fi
+          fi
+          echo "::set-output name=api_key::$api_key"
+          echo "::set-output name=branch::$branch"
+          echo "::set-output name=tf_scope::$tf_scope"
+          echo "::set-output name=tmt_repo::$tmt_repo"
+          echo "::set-output name=compose::$compose"
+          echo "::set-output name=context::$context"
+          echo "::set-output name=tmt_plan::$tmt_plan"
+        shell: bash
+
       # https://github.com/sclorg/testing-farm-as-github-action
       - name: Schedule tests on external Testing Farm by Testing-Farm-as-github-action
         id: github_action
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          api_key: ${{ secrets[matrix.api_key] }}
-          git_url: ${{ matrix.tmt_repo }}
-          git_ref: ${{ matrix.branch }}
-          tf_scope: ${{ matrix.tf_scope }}
-          tmt_plan_regex: ${{ matrix.tmt_plan }}
-          pull_request_status_name: ${{ matrix.context }}
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os_test }};TEST_NAME=test"
-          compose: ${{ matrix.compose }}
+          api_key: ${{ steps.vars.outputs.api_key }}
+          git_url: ${{ steps.vars.outputs.tmt_repo }}
+          git_ref: ${{ steps.vars.outputs.branch }}
+          tf_scope: ${{ steps.vars.outputs.tf_scope }}
+          tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
+          pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ matrix.container-to-test }}"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os }};TEST_NAME=test;TESTED_IMAGE=${{ matrix.container-to-test }}"
+          compose: ${{ steps.vars.outputs.compose }}


### PR DESCRIPTION
This pull request is the first part of separation tasks.

This GitHub action calls each container in alone CI machine. We will see results faster and can easily analyze, which container failed.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>