### PR TITLE
Separate container tests into alone CI test - part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL := /usr/bin/env bash
 
 all:
-	@echo >&2 "Only 'make check' allowed"
+	@echo >&2 "Only 'make shellcheck', 'make test', or 'make test-openshift-4' are allowed"
 
-.PHONY: check test all check-failures
+.PHONY: test all check-failures check-squash check-latest-imagestream test test-openshift-4
 
 TEST_LIB_TESTS = \
 	path_foreach \
@@ -20,10 +20,10 @@ test-lib-foreach:
 
 check-test-lib: $(TEST_LIB_TESTS)
 
-test: check
+test: check-failures check-squash check-latest-imagestream
 	TESTED_SCENARIO=test tests/remote-containers.sh
 
-test-openshift-4: check
+test-openshift-4: check-failures check-squash check-latest-imagestream
 	TESTED_SCENARIO=test-openshift-4 tests/remote-containers.sh
 
 shellcheck:
@@ -46,5 +46,3 @@ check-latest-imagestream:
 
 check-betka:
 	cd tests && ./check_betka.sh
-
-check: check-failures check-squash check-latest-imagestream

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,7 @@ SHELL := /usr/bin/env bash
 all:
 	@echo >&2 "Only 'make check' allowed"
 
-
-TESTED_IMAGES = \
-	postgresql-container \
-	s2i-python-container \
-	s2i-nodejs-container
-
 .PHONY: check test all check-failures
-
 
 TEST_LIB_TESTS = \
 	path_foreach \
@@ -28,6 +21,10 @@ test-lib-foreach:
 check-test-lib: $(TEST_LIB_TESTS)
 
 test: check
+	TESTED_SCENARIO=test tests/remote-containers.sh
+
+test-openshift-4: check
+	TESTED_SCENARIO=test-openshift-4 tests/remote-containers.sh
 
 shellcheck:
 	./run-shellcheck.sh `git ls-files *.sh`
@@ -50,7 +47,4 @@ check-latest-imagestream:
 check-betka:
 	cd tests && ./check_betka.sh
 
-check-remote-containers:
-	TESTED_IMAGES="$(TESTED_IMAGES)" tests/remote-containers.sh
-
-check: check-failures check-squash check-latest-imagestream check-remote-containers
+check: check-failures check-squash check-latest-imagestream

--- a/tests/remote-containers.sh
+++ b/tests/remote-containers.sh
@@ -2,9 +2,9 @@
 
 IMAGE_REVISION=master
 
-test -n "${OS-}" || false 'make sure $OS is defined'
-test -n "${TESTED_IMAGE-}" || false 'make sure $TESTED_IMAGE is defined'
-test -n "${TESTED_SCENARIO-}" || false 'make sure $TESTED_SCENARIO is defined'
+test -n "${OS-}" || (echo 'make sure $OS is defined' >&2 ; exit 1)
+test -n "${TESTED_IMAGE-}" || (echo 'make sure $TESTED_IMAGE is defined' >&2 ; exit 1)
+test -n "${TESTED_SCENARIO-}" || (echo 'make sure $TESTED_SCENARIO is defined' >&2 ; exit 1)
 
 MERGE_INTO=origin/master
 

--- a/tests/remote-containers.sh
+++ b/tests/remote-containers.sh
@@ -1,12 +1,10 @@
 #! /bin/bash
 
-declare -A IMAGES
-
-for image in ${TESTED_IMAGES}; do
-    IMAGES[$image]=master
-done
+IMAGE_REVISION=master
 
 test -n "${OS-}" || false 'make sure $OS is defined'
+test -n "${TESTED_IMAGE-}" || false 'make sure $TESTED_IMAGE is defined'
+test -n "${TESTED_SCENARIO-}" || false 'make sure $TESTED_SCENARIO is defined'
 
 MERGE_INTO=origin/master
 
@@ -39,7 +37,7 @@ analyse_commits ()
                 IFS=$old_IFS
                 set -- $1 $2
                 info "PR commits ask for testing $1 from PR $2"
-                IMAGES[$1]=$2
+                IMAGE_REVISION=$2
                 ;;
         esac
     done < <(git log --format=%B --reverse "$MERGE_INTO"..HEAD)
@@ -50,67 +48,64 @@ analyse_commits
 test_short_summary=""
 TESTSUITE_RESULT=0
 
-for image in "${!IMAGES[@]}"; do
-    # We don't want to remove user's WIP stuff.
-    test -e "$image" && die "directory '$image' exists"
+# We don't want to remove user's WIP stuff.
+test -e "$TESTED_IMAGE" && die "directory '$TESTED_IMAGE' exists"
 
-    (   testdir=$PWD
-        cleanup () {
-            set -x
-            # Ensure the cleanup finishes!
-            trap '' INT
-            # Go back, wherever we are.
-            cd "$testdir"
-            # Try to cleanup, if available (and if needed).
-            make clean -C "$image" || :
-            # Drop the image sources.
-            test ! -d "$image" || rm -rf "$image"
-        }
-        trap cleanup EXIT
+(   testdir=$PWD
+    cleanup () {
+        set -x
+        # Ensure the cleanup finishes!
+        trap '' INT
+        # Go back, wherever we are.
+        cd "$testdir"
+        # Try to cleanup, if available (and if needed).
+        make clean -C "$image" || :
+        # Drop the image sources.
+        test ! -d "$image" || rm -rf "$image"
+    }
+    trap cleanup EXIT
 
-        info "Testing $image image"
+    info "Testing $TESTED_IMAGE image"
 
-        # Use --recursive even if we remove 'common', because there might be
-        # other git submodules which need to be tested.
-        git clone --recursive -q https://github.com/sclorg/"$image".git
-        cd "$image"
+    # Use --recursive even if we remove 'common', because there might be
+    # other git submodules which need to be tested.
+    git clone --recursive -q https://github.com/sclorg/"$TESTED_IMAGE".git
+    cd "$TESTED_IMAGE"
 
-        revision=${IMAGES[$image]}
-        if ! test "$revision" = master; then
-            info "Fetching $image PR $revision"
-            git fetch origin "pull/$revision/head":PR_BRANCH
-            git checkout PR_BRANCH
-            git submodule update
-        fi
-
-        # We fail if the 'common' directory doesn't exist.
-        test -d common
-        rm -rf common
-        info "Replacing common with PR's version"
-        ln -s ../ common
-
-        # TODO: Do we have to test all $(VERSION)s?
-        # TODO: The PS4 hack doesn't work if we run the testsuite as UID=0.
-        PS4="+ [$image] " make TARGET="$OS" test
-        test_ret_value=$?
-        # Cleanup.
-        make clean
-
-        if test $test_ret_value -eq 0 ; then
-          info "Tests for $image succeeded."
-          exit 0
-        else
-          info "Tests for $image failed."
-          exit 1
-        fi
-    )
-    if test $? -eq 0 ; then
-      printf -v test_short_summary "${test_short_summary}[PASSED] $image\n"
-    else
-      printf -v test_short_summary "${test_short_summary}[FAILED] $image\n"
-      TESTSUITE_RESULT=1
+    if ! test "${IMAGE_REVISION}" = master; then
+        info "Fetching $image PR ${IMAGE_REVISION}"
+        git fetch origin "pull/${IMAGE_REVISION}/head":PR_BRANCH
+        git checkout PR_BRANCH
+        git submodule update
     fi
-done
+
+    # We fail if the 'common' directory doesn't exist.
+    test -d common
+    rm -rf common
+    info "Replacing common with PR's version"
+    ln -s ../ common
+
+    # TODO: Do we have to test all $(VERSION)s?
+    # TODO: The PS4 hack doesn't work if we run the testsuite as UID=0.
+    PS4="+ [$TESTED_IMAGE] " make TARGET="$OS" $TESTED_SCENARIO
+    test_ret_value=$?
+    # Cleanup.
+    make clean
+
+    if test $test_ret_value -eq 0 ; then
+      info "Tests for $image succeeded."
+      exit 0
+    else
+      info "Tests for $image failed."
+      exit 1
+    fi
+)
+if test $? -eq 0 ; then
+  printf -v test_short_summary "${test_short_summary}[PASSED] $TESTED_IMAGE\n"
+else
+  printf -v test_short_summary "${test_short_summary}[FAILED] $TESTED_IMAGE\n"
+  TESTSUITE_RESULT=1
+fi
 
 echo "$test_short_summary"
 if [ $TESTSUITE_RESULT -eq 0 ] ; then


### PR DESCRIPTION
This pull request adds support for real testing containers by container-common-scripts.

The command for running tests is:
```bash
TESTED_IMAGE=postgresql-container make test OS=<OS>
```

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>