### PR TITLE
Add missing Dockerfile.rhel9 for Makefile target failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ pre-commit-check:
 
 check-failures: check-test-lib
 	cd tests/failures/check && make tag && ! make check && make clean
-	grep -q "Red Hat Enterprise Linux release 8" /etc/system-release || cd tests/failures/check && make tag SKIP_SQUASH=0
+	cd tests/failures/check && ./check_skip_squash.sh
 
 check-squash:
 	./tests/squash/squash.sh

--- a/tests/failures/check/check_skip_squash.sh
+++ b/tests/failures/check/check_skip_squash.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if grep -q "Red Hat Enterprise Linux release 8" /etc/system-release || grep -q "Red Hat Enterprise Linux release 9" /etc/system-release ; then
+  echo "make tag SKIP_SQUASH=0 is skipped on RHEL8 and RHEL 9."
+  exit 0
+fi
+
+make tag SKIP_SQUASH=0

--- a/tests/failures/check/v0/Dockerfile.rhel9
+++ b/tests/failures/check/v0/Dockerfile.rhel9
@@ -1,0 +1,2 @@
+FROM ubi9/s2i-core
+LABEL name=test-image

--- a/tests/squash/squash.sh
+++ b/tests/squash/squash.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-if grep -q "Red Hat Enterprise Linux release 8" /etc/system-release; then
-  # No use testing squash.py on rhel8 for now as it does not work at all
-  echo "  ! test case ignored on RHEL8 host"
+if grep -q "Red Hat Enterprise Linux release 8" /etc/system-release || grep -q "Red Hat Enterprise Linux release 9" /etc/system-release ; then
+  # No use testing squash.py on rhel8 and rhel9 for now as it does not work at all
+  echo "  ! test case ignored on RHEL8 and RHEL9 host"
   exit 0
 fi
 


### PR DESCRIPTION
This pull request adds a missing test for container-common-scripts Makefile target failures.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>