### PR TITLE
Fixes for proper handling test in CVP pipeline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ is scanned as well.
 `CT_OCP4_TEST`
 Set to true if you want to test container in OpenShift 4 environment.
 
+`CVP`
+Set to true if you want to test container in Container Validation Pipeline environment.
+
 `clean-hook`
 Append Makefile rules to this variable to make sure additional cleaning actions are run
 when `make clean` is called.

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -112,7 +112,7 @@ function ct_os_run_in_pod() {
 # Arguments: service_name - name of the service
 function ct_os_get_service_ip() {
   local service_name="${1}" ; shift
-  ocp_docker_address='172\.30\.[0-9\.]*'
+  local ocp_docker_address='172\.30\.[0-9\.]*'
   if [ "${CVP:-0}" -eq "1" ]; then
     # shellcheck disable=SC2034
     ocp_docker_address='172\.27\.[0-9\.]*'
@@ -399,7 +399,7 @@ function ct_os_delete_project() {
 # Deletes all objects within the project.
 # Handy when we have one project and want to run more tests.
 function ct_delete_all_objects() {
-  objects="bc builds dc is isimage istag po pv pvc rc routes secrets svc"
+  local objects="bc builds dc is isimage istag po pv pvc rc routes secrets svc"
   if [ "${CVP:-0}" -eq "1" ]; then
     echo "Testing in CVP environment. No need to delete isimage and istag in OpenShift project. This is done by CVP pipeline"
     objects="bc builds dc po pvc rc routes"

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -112,8 +112,14 @@ function ct_os_run_in_pod() {
 # Arguments: service_name - name of the service
 function ct_os_get_service_ip() {
   local service_name="${1}" ; shift
+  ocp_docker_address='172\.30\.[0-9\.]*'
+  if [ "${CVP:-0}" -eq "1" ]; then
+    # shellcheck disable=SC2034
+    ocp_docker_address='172\.27\.[0-9\.]*'
+  fi
+  # shellcheck disable=SC2016
   oc get "svc/${service_name}" -o yaml | grep clusterIP | \
-     cut -d':' -f2 | grep -oe '172\.30\.[0-9\.]*'
+     cut -d':' -f2 | grep -oe '$ocp_docker_address'
 }
 
 
@@ -188,6 +194,7 @@ function ct_os_get_pod_ip() {
 # Arguments: pod_name
 function ct_os_get_sti_build_logs() {
   local pod_prefix="${1}"
+  oc status --suggest
   pod_name=$(ct_os_get_buildconfig_pod_name "${pod_prefix}")
   # Print logs but do not failed. Just for traces
   if [ x"${pod_name}" != "x" ]; then
@@ -392,7 +399,13 @@ function ct_os_delete_project() {
 # Deletes all objects within the project.
 # Handy when we have one project and want to run more tests.
 function ct_delete_all_objects() {
-  for x in bc builds dc is isimage istag po pv pvc rc routes secrets svc ; do
+  objects="bc builds dc is isimage istag po pv pvc rc routes secrets svc"
+  if [ "${CVP:-0}" -eq "1" ]; then
+    echo "Testing in CVP environment. No need to delete isimage and istag in OpenShift project. This is done by CVP pipeline"
+    objects="bc builds dc po pvc rc routes"
+  fi
+  for x in $objects; do
+    oc get "$x"
     oc delete "$x" --all
   done
   # for some objects it takes longer to be really deleted, so a dummy sleep

--- a/test-openshift.yaml
+++ b/test-openshift.yaml
@@ -51,7 +51,12 @@
           shell: oc project {{ openshift_project_name }}
 
         - name: Import the image into OpenShift
-          shell: oc import-image {{ image_name }} --from={{ image_full_name }} --insecure=true --confirm
+          shell: oc import-image {{ image_name }}:{{ environment[0]['VERSION'] }} --from={{ image_full_name }} --insecure=true --confirm
+          retries: 3
+          delay: 10
+
+        - name: Tag image into OpenShift
+          shell: oc tag {{ image_name }}:{{ environment[0]['VERSION'] }} nodejs:{{ environment[0]['VERSION'] }}
           retries: 3
           delay: 10
 
@@ -68,4 +73,4 @@
 
         # Run tests on OpenShift 4
         - name: Run a sclorg test suite in OpenShift 4
-          shell: VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash test/run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log
+          shell: VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash ./run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log

--- a/test-openshift.yaml
+++ b/test-openshift.yaml
@@ -18,6 +18,7 @@
   environment:
     VERSION: VERSION_NUMBER
     OS: OS_NUMBER
+    SHORT_NAME: CONTAINER_NAME
     IMAGE_FULL_NAME: "{{ image_full_name }}"
     IMAGE_REGISTRY_URL: "{{ image_registry_url }}"
     IMAGE_NAMESPACE: "{{ image_namespace }}"
@@ -56,7 +57,7 @@
           delay: 10
 
         - name: Tag image into OpenShift
-          shell: oc tag {{ image_name }}:{{ environment[0]['VERSION'] }} nodejs:{{ environment[0]['VERSION'] }}
+          shell: oc tag {{ image_name }}:{{ environment[0]['VERSION'] }} {{ environment[0]['SHORT_NAME'}}:{{ environment[0]['VERSION'] }}
           retries: 3
           delay: 10
 
@@ -73,4 +74,4 @@
 
         # Run tests on OpenShift 4
         - name: Run a sclorg test suite in OpenShift 4
-          shell: VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash ./run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log
+          shell: VERSION={{ environment[0]['VERSION'] }} IMAGE_NAME={{ image_name }} OS={{ environment[0]['OS'] }} CVP=1 bash {{ playbook_dir }}/run-openshift-remote-cluster  | tee {{ cvp_artifacts_dir }}/{{ image_name }}.log


### PR DESCRIPTION
Fixes for proper handling test in CVP pipeline.

* correct detection of docker address
* print 'oc status --suggest' for getting logs
* delete proper objects in CVP pipeline
* Tag image in CVP pipeline to proper version
* fix calling path in test-openshift.yml

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>