### PR TITLE
Add support for testing single_version

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,12 @@
 
 set -e
 
+# This adds backwards compatibility if only single version needs to be testing
+# In CI we would like to test single version but VERSIONS= means, that nothing is tested
+# make test TARGET=<OS> VERSIONS=<something> ... checks single version for CLI
+# make test TARGET=<OS> SINGLE_VERSION=<something> ... checks single version from Testing Farm
+VERSIONS=${SINGLE_VERSION:-$VERSIONS}
+
 for dir in ${VERSIONS}; do
   [ ! -e "${dir}/.image-id" ] && echo "-> Image for version $dir not built, skipping tests." && continue
   pushd "${dir}" > /dev/null


### PR DESCRIPTION
Add support for testing single_version in case `make test VERSIONS=` is called
then no version is tested.

This pull request is needed by
https://github.com/sclorg/sclorg-testing-farm/pull/37

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>