### PR TITLE
Fix checking docker_address

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -112,14 +112,14 @@ function ct_os_run_in_pod() {
 # Arguments: service_name - name of the service
 function ct_os_get_service_ip() {
   local service_name="${1}" ; shift
-  local ocp_docker_address='172\.30\.[0-9\.]*'
+  local ocp_docker_address="172\.30\.[0-9\.]*"
   if [ "${CVP:-0}" -eq "1" ]; then
     # shellcheck disable=SC2034
-    ocp_docker_address='172\.27\.[0-9\.]*'
+    ocp_docker_address="172\.27\.[0-9\.]*"
   fi
   # shellcheck disable=SC2016
   oc get "svc/${service_name}" -o yaml | grep clusterIP | \
-     cut -d':' -f2 | grep -oe '$ocp_docker_address'
+     cut -d':' -f2 | grep -oe "$ocp_docker_address"
 }
 
 


### PR DESCRIPTION
The original code is here which was used before CVP (https://github.com/sclorg/container-common-scripts/commit/23d3e8b5f6f77c7624a314f15c32f1d5aaa62ff3#diff-1a059cdb3760c3d0e33b1ef71241a1f88e1f4e8d7390d29bd5f86a44b090ec4a).

But new definition expands ocp_docker_address to `172\\.30\\.[0-9\\.]*` which is wrong.
After changing from single quotes to double quotes the ocp_docker_address is `172\.30\.[0-9\.]*`. The tests are going well and IP address is getting it properly.


Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>