### PR TITLE
Replace s2i-nodejs-container with nginx-container and s2i-perl-container

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-to-test: ["postgresql-container", "s2i-nodejs-container", "s2i-python-container"]
+        container-to-test: ["postgresql-container", "nginx", "s2i-perl-container", "s2i-python-container"]
         os: ["fedora", "centos7", "rhel7", "rhel8", "rhel9"]
 
     if: |

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-to-test: ["postgresql-container", "nginx", "s2i-perl-container", "s2i-python-container"]
+        container-to-test: ["postgresql-container", "nginx-container", "s2i-perl-container", "s2i-python-container"]
         os: ["fedora", "centos7", "rhel7", "rhel8", "rhel9"]
 
     if: |


### PR DESCRIPTION
Because s2i-nodejs-container is still failing on `pino` upstream problem,

let's get remove it with s2i-perl and nginx-containers which are stable.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>