### PR TITLE
test-lib: add test for run_all_tests function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TEST_LIB_TESTS = \
 	random_string \
 	test_npm \
 	image_availability \
+	run_all_tests\
 	public_image_name
 
 $(TEST_LIB_TESTS):

--- a/tests/test-lib/run_all_tests
+++ b/tests/test-lib/run_all_tests
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+. ./test-lib.sh
+
+
+function foo_neg() {
+  echo "running foo_neg"
+  TESTCASE_RESULT=1
+}
+function bar() {
+  echo "running bar"
+  TESTCASE_RESULT=0
+}
+function foo() {
+  echo "running foo"
+  TESTCASE_RESULT=0
+}
+
+TEST_SET_POS="foo bar"
+TEST_SET_NEG="foo_neg bar"
+UNSTABLE_TESTS=""
+IGNORE_UNSTABLE_TESTS=0
+
+# positive test
+CID_FILE_DIR=$(mktemp -d)
+TEST_SUMMARY=""
+TEST_SET=${TEST_SET_POS} ct_run_tests_from_testset "should_pass" >> /dev/null
+(ct_cleanup >> /dev/null)
+test $? -eq 0
+
+# negative test
+CID_FILE_DIR=$(mktemp -d)
+TEST_SUMMARY=""
+TEST_SET=${TEST_SET_NEG} ct_run_tests_from_testset "should_fail" >> /dev/null
+(ct_cleanup >> /dev/null)
+test $? -eq 1


### PR DESCRIPTION
The test tests if testsuite ends with error if any ran test failed and if it ends with success if all tests pass.