### PR TITLE
introduce OC_ERR return value for openshift-related failures

### DIFF
--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -3,6 +3,11 @@
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")"/test-lib.sh
 
+# this should be returned when something related to the openshift cluster
+# goes wrong during the test pipeline
+# shellcheck disable=SC2034
+readonly OC_ERR=11
+
 # Set of functions for testing docker images in OpenShift using 'oc' command
 
 # A variable containing the overall test result


### PR DESCRIPTION
With removing exit on error (`set -e`) in the openshift tests (in the `run-openshift-remote-cluster`) we no longer check if something went wrong in the OC setup.
With this exit code it would be easier to classify, that the problem was with openshift and not with the tests themselves. It could be used like this: https://github.com/sclorg/nginx-container/pull/215


I am however not sure about the naming of the variable, if you have any better ideas let me please know.