### PR TITLE
Fix calling ct_os_upload_image

### DIFF
--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -107,7 +107,7 @@ function ct_os_import_image_ocp4() {
   local imagestream=${1:-$image_name:latest}
 
   echo "Uploading image ${image_name} as ${imagestream} into OpenShift internal registry."
-  ct_os_upload_image_v4 "${image_name}" "${imagestream}"
+  ct_os_upload_image "v4" "${image_name}" "${imagestream}"
 
 }
 


### PR DESCRIPTION
The pull request fixes typo in function ct_os_import_image_ocp4.

There is no function like `ct_os_upload_image_v4` but `ct_os_upload_image` with parameter "v4"
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>