### PR TITLE
remove also pulled image when cleaning

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -4,16 +4,15 @@
 
 test -f auto_targets.mk && rm auto_targets.mk
 
-for version
-do
-    remove_images=
-    # shellcheck disable=SC2039,SC3024
-    test ! -f "$version/.image-id" || remove_images+=" $(cat "$version/.image-id")"
-    for image in $remove_images; do
-        # shellcheck disable=SC2046
-        docker rm -f $(docker ps -q -a -f "ancestor=$image") 2>/dev/null
-        docker rmi -f "$image"
-    done
-
-    rm -rf "$version"/.image-id*
+for version; do
+  for id_file in .image-id .image-id-from; do
+    if [ -f "$version"/"$id_file" ]; then
+      image="$(cat "$version"/"$id_file")"
+      test -n "$image" || continue
+      containers="$(docker ps -q -a -f ancestor="$image")"
+      docker rm -f "$containers" 2>/dev/null
+      docker rmi -f "$image"
+      rm -f "$version"/"$id_file"
+    fi
+  done
 done


### PR DESCRIPTION
After 'make build' the base image is pulled on top of which is built the new container image.
This commit enables removal of such a pulled image when calling 'make clean'.
The image will not be removed if it was available locally before the pull.