### PR TITLE
Sanity checks

### DIFF
--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         id: pr_nr
         run: |
           PR_URL="${{ github.event.comment.issue_url }}"
-          echo "::set-output name=PR_NR::${PR_URL##*/}"
+          echo "PR_NR=${PR_URL##*/}" >> $GITHUB_OUTPUT
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
       - name: Get sha
         id: sha
         run: |
-          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+          echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Install needed dependences for sanity checks
         id: sched_test
@@ -59,7 +59,7 @@ jobs:
         run: |
           set +e
           make pre-commit-check
-          echo ::set-output name=exit_status::$?
+          echo "exit_status=$?" >> $GITHUB_OUTPUT
 
       - name: Switch to final state
         run: |

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install needed dependences for sanity checks
         id: sched_test
         run: |
-          sudo apt-get update && sudo apt-get -y install curl jq make git shellcheck python3 python3-pip
+          sudo apt-get update && sudo apt-get -y install curl jq make git python3 python3-pip
           pip3 install pre-commit
 
       - name: Create status check to pending
@@ -53,14 +53,6 @@ jobs:
             https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{ steps.sha.outputs.SHA }} \
             --data @pending.json
 
-
-      - name: Run Sanity shell tests
-        id: shellcheck_tests
-        continue-on-error: true
-        run: |
-          set +e
-          make shellcheck
-          echo ::set-output name=exit_status::$?
       - name: Run Sanity pre-commit tests
         continue-on-error: true
         id: pre_commit_tests
@@ -71,10 +63,9 @@ jobs:
 
       - name: Switch to final state
         run: |
-          echo "Result from shellcheck_tests is ${{ steps.shellcheck_tests.outputs.exit_status }}"
           echo "Result from pre_commit_tests is ${{ steps.pre_commit_tests.outputs.exit_status }}"
 
-          if [[ ${{ steps.shellcheck_tests.outputs.exit_status }} == 0 ]] && [[ ${{ steps.pre_commit_tests.outputs.exit_status }} == 0 ]]; then
+          if [[ ${{ steps.pre_commit_tests.outputs.exit_status }} == 0 ]]; then
             FINAL_STATE="success"
           else
             FINAL_STATE="failure"


### PR DESCRIPTION
- remove shellcheck from sanity check as it is redundant now (we have it covered in differential shellcheck action)
- rework sanity-tests action to use $GITHUB_OUTPUT