### PR TITLE
cgroups: return None if number of cores can not be obtained

### DIFF
--- a/shared-scripts/core/usr/bin/cgroup-limits
+++ b/shared-scripts/core/usr/bin/cgroup-limits
@@ -70,10 +70,10 @@ def get_number_of_cores():
     Read number of CPU cores.
     """
 
-    limits = [_read_cpu_quota(), _read_cpuset_size()]
+    limits = [l for l in [_read_cpu_quota(), _read_cpuset_size()] if l]
     if not limits:
         return None
-    return min([l for l in limits if l])
+    return min(limits)
 
 
 def _read_cpu_quota():


### PR DESCRIPTION
Fixes: https://github.com/sclorg/postgresql-container/issues/482