### PR TITLE
Make cgroup-limits script work for non-root containers

### DIFF
--- a/shared-scripts/core/usr/bin/cgroup-limits
+++ b/shared-scripts/core/usr/bin/cgroup-limits
@@ -146,7 +146,7 @@ def _read_cpuset_size():
     if line is None:
         # None of the files above exists when running podman as non-root,
         # so in that case, this warning is printed every-time
-        print("Warning: Can't detect cpuset size from cgroups",
+        print("Warning: Can't detect cpuset size from cgroups, will use nproc",
               file=sys.stderr)
         return None
 
@@ -168,8 +168,11 @@ def _read_nproc():
     configuration (per podman-run(1) man page).
     """
     try:
-        return int(subprocess.run('nproc', capture_output=True).stdout)
-    except FileNotFoundError:
+        stdout, stderr = subprocess.Popen('nproc', stdout=subprocess.PIPE).communicate()
+        return int(stdout)
+    except EnvironmentError as e:
+        if e.errno != errno.ENOENT:
+            raise
         return None
 
 

--- a/shared-scripts/core/usr/bin/cgroup-limits
+++ b/shared-scripts/core/usr/bin/cgroup-limits
@@ -33,11 +33,35 @@ Variables currently supported:
     NO_MEMORY_LIMIT
         Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
         can act as if no memory limit was set. Undefined otherwise.
+
+Note about non-root containers:
+
+    Per podman-run(1) man page, on some systems, changing the resource limits
+    may not be allowed for non-root users. For more details, see
+    https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error.
+
+How to test this script:
+
+    Run a container as root and see whether the output of available memory
+    and CPUs match what is either available on the host or specified via
+    cgroups limits by the container runtime (podman).
+
+    For example:
+
+    # This should return NO_MEMORY_LIMIT=true, NUMBER_OF_CORES=<what host has>
+    sudo podman run -ti --rm quay.io/fedora/s2i-core /usr/bin/cgroup-limits
+
+    # This should return MEMORY_LIMIT_IN_BYTES=2147483648, NUMBER_OF_CORES=3
+    # 3 CPUs despite --cpus 4 was given is correct, because the cpuset 2-4 means
+    # running on 3 concrete processors only, which is lower limit than --cpus
+    # and thus is preferred
+    sudo podman run -ti --rm --cpus 4 --cpuset-cpus=2-4 --memory 2G quay.io/fedora/s2i-core /usr/bin/cgroup-limits
 """
 
 from __future__ import division
 from __future__ import print_function
 import sys
+import subprocess
 
 
 def _read_file(path):
@@ -70,7 +94,7 @@ def get_number_of_cores():
     Read number of CPU cores.
     """
 
-    limits = [l for l in [_read_cpu_quota(), _read_cpuset_size()] if l]
+    limits = [l for l in [_read_cpu_quota(), _read_cpuset_size(), _read_nproc()] if l]
     if not limits:
         return None
     return min(limits)
@@ -134,6 +158,19 @@ def _read_cpuset_size():
             core_count += 1
 
     return core_count
+
+
+def _read_nproc():
+    """
+    Returns number of cores without looking at cgroup limits.
+    This might work as the last resort when running a container as non-root
+    where cgroups v2 resource limits cannot be set without a specific
+    configuration (per podman-run(1) man page).
+    """
+    try:
+        return int(subprocess.run('nproc', capture_output=True).stdout)
+    except FileNotFoundError:
+        return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resource limits detection was enhanced via:
https://github.com/sclorg/container-common-scripts/pull/237 While this is not directly connected, mentioning to connect both issues that touch resource limits detection.

Per podman-run(1) man page, on some systems, changing the resource limits may not be allowed for non-root users. For more details, see https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error.

This caused the cgroup-limits script to fail with python traceback:

```
$ podman run -ti --rm quay.io/fedora/s2i-core:37 /usr/bin/cgroup-limits Warning: Can't detect cpu quota from cgroups
Warning: Can't detect cpuset size from cgroups
Traceback (most recent call last):
  File /usr/bin/cgroup-limits, line 143, in <module>
    NUMBER_OF_CORES: get_number_of_cores()
                       ^^^^^^^^^^^^^^^^^^^^^
  File /usr/bin/cgroup-limits, line 76, in get_number_of_cores
    return min([l for l in limits if l])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() arg is an empty sequence
```

This change implements another way to see number of CPUs (without cgroups), using nproc tool.

This might work as the last resort when running a container as non-root, so we get the same output as when the same container is run as a root on the same machine.

Also tracked internally: https://issues.redhat.com/browse/RHELPLAN-141599