### PR TITLE
adding sclorg tfaga wrapper

### DIFF
--- a/sclorg-tfaga-wrapper/README.md
+++ b/sclorg-tfaga-wrapper/README.md
@@ -1,0 +1,8 @@
+sclorg-tfaga-wrapper (Software Collections Organization's wrapper for Testing Farm as a GitHub Action)
+
+This wrapper tries to minimize lines of code needed to be written in each
+container repository when calling TFaGA.
+This should lead to code reduction, dumplicity removal,
+easier maintaining and adding features.
+
+This action is only for Pull Request comment triggers.

--- a/sclorg-tfaga-wrapper/action.yml
+++ b/sclorg-tfaga-wrapper/action.yml
@@ -13,6 +13,12 @@ inputs:
   test_case:
     description: 'container/openshift'
     required: true
+  public_api_key:
+    description: ''
+    required: true
+  private_api_key:
+    description: ''
+    required: true
 
 runs:
   using: 'composite'
@@ -30,6 +36,19 @@ runs:
       id: vars
       run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
 
+    - name: Use correct API key
+      shell: bash
+      id: api_key
+      run: |
+        if [ "${{ steps.vars.outputs.api_key }}" == "TF_PUBLIC_API_KEY" ]; then
+          echo "value=${{ inputs.public_api_key }}" >> "$GITHUB_OUTPUT"
+        elif [ "${{ steps.vars.outputs.api_key }}" == "TF_PRIVATE_API_KEY" ]; then
+          echo "value=${{ inputs.private_api_key }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "err, invalid API_KEY value" >&2
+          exit 2
+        fi
+
     - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }} is present
       id: check_dockerfile
       uses: andstor/file-existence-action@v1
@@ -46,7 +65,7 @@ runs:
       if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
       uses: sclorg/testing-farm-as-github-action@v1
       with:
-        api_key:  ${{ secrets[steps.vars.outputs.api_key] }}
+        api_key:  ${{ steps.api_key.outputs.value }}
         compose:  ${{ steps.vars.outputs.compose }}
         git_url:  ${{ steps.vars.outputs.tmt_repo }}
         git_ref:  ${{ steps.vars.outputs.branch }}

--- a/sclorg-tfaga-wrapper/action.yml
+++ b/sclorg-tfaga-wrapper/action.yml
@@ -1,0 +1,79 @@
+---
+
+name: 'Run Testing Farm as GitHub Action for SCLOrg use-cases'
+author: 'RHSCL team'
+
+inputs:
+  compose:
+    description: ''
+    required: true
+  api_key:
+    description: ''
+    required: true
+  git_url:
+    description: ''
+    required: true
+  git_ref:
+    description: ''
+    required: true
+  tf_scope:
+    description: ''
+    required: true
+  tmt_plan_regex:
+    description: ''
+    required: true
+  pull_request_status_name:
+    description: ''
+    required: true
+  version:
+    description: ''
+    required: true
+  os_test:
+    description: ''
+    required: true
+  test_name:
+    description: ''
+    required: true
+
+runs:
+  using: 'composite'
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
+      - name: Prepare needed variables
+        shell: bash
+        id: vars
+        run: |
+          dockerfile="Dockerfile.${{ inputs.os_test }}"
+          if [[ ${{ inputs.os_test }} == "centos7" ]]; then
+            dockerfile="Dockerfile"
+          fi
+          echo "DOCKERFILE_NAME=${dockerfile}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }} is present
+        id: check_dockerfile
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ inputs.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }}"
+
+      - name: Check .exclude-${{ inputs.os_test }} file presents
+        id: check_exclude_file
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ inputs.version }}/.exclude-${{ inputs.os_test }}"
+
+      - name: Schedule tests for ${{ inputs.version }} - ${{ inputs.context }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
+        uses: sclorg/testing-farm-as-github-action@v1
+        with:
+          api_key: ${{ secrets[inputs.api_key] }}
+          git_url: ${{ inputs.tmt_repo }}
+          git_ref: ${{ inputs.branch }}
+          tf_scope: ${{ inputs.tf_scope }}
+          tmt_plan_regex: ${{ inputs.tmt_plan }}
+          pull_request_status_name: "${{ inputs.context }} - ${{ inputs.version }}"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ inputs.version }};OS=${{ inputs.os_test }};TEST_NAME=${{ inputs.test_name }}"
+          compose: ${{ inputs.compose }}

--- a/sclorg-tfaga-wrapper/action.yml
+++ b/sclorg-tfaga-wrapper/action.yml
@@ -16,44 +16,44 @@ inputs:
 
 runs:
   using: 'composite'
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          ref: "refs/pull/${{ github.event.issue.number }}/head"
+  steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: "refs/pull/${{ github.event.issue.number }}/head"
 
-      - name: Prepare needed variables
-        shell: bash
-        id: vars
-        run: ./export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
+    - name: Prepare needed variables
+      shell: bash
+      id: vars
+      run: ./export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
 
-      - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }} is present
-        id: check_dockerfile
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }}"
+    - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }} is present
+      id: check_dockerfile
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }}"
 
-      - name: Check .exclude-${{ steps.vars.outputs.os_test }} file presents
-        id: check_exclude_file
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ inputs.version }}/.exclude-${{ steps.vars.outputs.os_test }}"
+    - name: Check .exclude-${{ steps.vars.outputs.os_test }} file presents
+      id: check_exclude_file
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "${{ inputs.version }}/.exclude-${{ steps.vars.outputs.os_test }}"
 
-      - name: Schedule tests for ${{ inputs.version }} - ${{ steps.vars.outputs.os_test }}
-        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && \
-                steps.check_dockerfile.outputs.files_exists == 'true' }}
-        uses: sclorg/testing-farm-as-github-action@v1
-        with:
-          api_key:  ${{ steps.vars.outputs.os_test }}
-          compose:  ${{ steps.vars.outputs.compose }}
-          git_url:  ${{ steps.vars.outputs.tmt_repo }}
-          git_ref:  ${{ steps.vars.outputs.branch }}
-          tf_scope: ${{ steps.vars.outputs.tf_scope }}
-          tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
-          pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ inputs.version }}"
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;" \
-                     "REPO_NAME=$GITHUB_REPOSITORY;" \
-                     "PR_NUMBER=${{ github.event.issue.number }};" \
-                     "SINGLE_VERSION=${{ inputs.version }};" \
-                     "OS=${{ steps.vars.outputs.os_test }};" \
-                     "TEST_NAME=${{ steps.vars.outputs.test_name }}"
+    - name: Schedule tests for ${{ inputs.version }} - ${{ steps.vars.outputs.os_test }}
+      if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && \
+              steps.check_dockerfile.outputs.files_exists == 'true' }}
+      uses: sclorg/testing-farm-as-github-action@v1
+      with:
+        api_key:  ${{ steps.vars.outputs.os_test }}
+        compose:  ${{ steps.vars.outputs.compose }}
+        git_url:  ${{ steps.vars.outputs.tmt_repo }}
+        git_ref:  ${{ steps.vars.outputs.branch }}
+        tf_scope: ${{ steps.vars.outputs.tf_scope }}
+        tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
+        pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ inputs.version }}"
+        variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;" \
+                   "REPO_NAME=$GITHUB_REPOSITORY;" \
+                   "PR_NUMBER=${{ github.event.issue.number }};" \
+                   "SINGLE_VERSION=${{ inputs.version }};" \
+                   "OS=${{ steps.vars.outputs.os_test }};" \
+                   "TEST_NAME=${{ steps.vars.outputs.test_name }}"

--- a/sclorg-tfaga-wrapper/action.yml
+++ b/sclorg-tfaga-wrapper/action.yml
@@ -4,35 +4,14 @@ name: 'Run Testing Farm as GitHub Action for SCLOrg use-cases'
 author: 'RHSCL team'
 
 inputs:
-  compose:
-    description: ''
-    required: true
-  api_key:
-    description: ''
-    required: true
-  git_url:
-    description: ''
-    required: true
-  git_ref:
-    description: ''
-    required: true
-  tf_scope:
-    description: ''
-    required: true
-  tmt_plan_regex:
-    description: ''
-    required: true
-  pull_request_status_name:
-    description: ''
-    required: true
   version:
     description: ''
     required: true
   os_test:
-    description: ''
+    description: 'centos7/c9s/fedora/rhel7/rhel8/rhel9/rhel9-unsubscribed'
     required: true
-  test_name:
-    description: ''
+  test_case:
+    description: 'container/openshift'
     required: true
 
 runs:
@@ -46,34 +25,35 @@ runs:
       - name: Prepare needed variables
         shell: bash
         id: vars
-        run: |
-          dockerfile="Dockerfile.${{ inputs.os_test }}"
-          if [[ ${{ inputs.os_test }} == "centos7" ]]; then
-            dockerfile="Dockerfile"
-          fi
-          echo "DOCKERFILE_NAME=${dockerfile}" >> "$GITHUB_OUTPUT"
+        run: ./export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
 
-      - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }} is present
+      - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }} is present
         id: check_dockerfile
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ inputs.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }}"
+          files: "${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }}"
 
-      - name: Check .exclude-${{ inputs.os_test }} file presents
+      - name: Check .exclude-${{ steps.vars.outputs.os_test }} file presents
         id: check_exclude_file
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ inputs.version }}/.exclude-${{ inputs.os_test }}"
+          files: "${{ inputs.version }}/.exclude-${{ steps.vars.outputs.os_test }}"
 
-      - name: Schedule tests for ${{ inputs.version }} - ${{ inputs.context }}
-        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
+      - name: Schedule tests for ${{ inputs.version }} - ${{ steps.vars.outputs.os_test }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && \
+                steps.check_dockerfile.outputs.files_exists == 'true' }}
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          api_key: ${{ secrets[inputs.api_key] }}
-          git_url: ${{ inputs.tmt_repo }}
-          git_ref: ${{ inputs.branch }}
-          tf_scope: ${{ inputs.tf_scope }}
-          tmt_plan_regex: ${{ inputs.tmt_plan }}
-          pull_request_status_name: "${{ inputs.context }} - ${{ inputs.version }}"
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ inputs.version }};OS=${{ inputs.os_test }};TEST_NAME=${{ inputs.test_name }}"
-          compose: ${{ inputs.compose }}
+          api_key:  ${{ steps.vars.outputs.os_test }}
+          compose:  ${{ steps.vars.outputs.compose }}
+          git_url:  ${{ steps.vars.outputs.tmt_repo }}
+          git_ref:  ${{ steps.vars.outputs.branch }}
+          tf_scope: ${{ steps.vars.outputs.tf_scope }}
+          tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
+          pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ inputs.version }}"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;" \
+                     "REPO_NAME=$GITHUB_REPOSITORY;" \
+                     "PR_NUMBER=${{ github.event.issue.number }};" \
+                     "SINGLE_VERSION=${{ inputs.version }};" \
+                     "OS=${{ steps.vars.outputs.os_test }};" \
+                     "TEST_NAME=${{ steps.vars.outputs.test_name }}"

--- a/sclorg-tfaga-wrapper/action.yml
+++ b/sclorg-tfaga-wrapper/action.yml
@@ -22,10 +22,13 @@ runs:
       with:
         ref: "refs/pull/${{ github.event.issue.number }}/head"
 
+    - run: echo "${{ github.action_path }}" >> "$GITHUB_PATH"
+      shell: bash
+
     - name: Prepare needed variables
       shell: bash
       id: vars
-      run: ./export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
+      run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
 
     - name: Check if ${{ inputs.version }}/${{ steps.vars.outputs.dockerfile }} is present
       id: check_dockerfile
@@ -40,20 +43,14 @@ runs:
         files: "${{ inputs.version }}/.exclude-${{ steps.vars.outputs.os_test }}"
 
     - name: Schedule tests for ${{ inputs.version }} - ${{ steps.vars.outputs.os_test }}
-      if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && \
-              steps.check_dockerfile.outputs.files_exists == 'true' }}
+      if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
       uses: sclorg/testing-farm-as-github-action@v1
       with:
-        api_key:  ${{ steps.vars.outputs.os_test }}
+        api_key:  ${{ secrets[steps.vars.outputs.api_key] }}
         compose:  ${{ steps.vars.outputs.compose }}
         git_url:  ${{ steps.vars.outputs.tmt_repo }}
         git_ref:  ${{ steps.vars.outputs.branch }}
         tf_scope: ${{ steps.vars.outputs.tf_scope }}
         tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
         pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ inputs.version }}"
-        variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;" \
-                   "REPO_NAME=$GITHUB_REPOSITORY;" \
-                   "PR_NUMBER=${{ github.event.issue.number }};" \
-                   "SINGLE_VERSION=${{ inputs.version }};" \
-                   "OS=${{ steps.vars.outputs.os_test }};" \
-                   "TEST_NAME=${{ steps.vars.outputs.test_name }}"
+        variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ inputs.version }};OS=${{ steps.vars.outputs.os_test }};TEST_NAME=${{ steps.vars.outputs.test_name }}"

--- a/sclorg-tfaga-wrapper/export_variables.sh
+++ b/sclorg-tfaga-wrapper/export_variables.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+public_ranch="centos7 c9s fedora"
+private_ranch="rhel7 rhel8 rhel9 rhel9-unsubscribed"
+all_os="$public_ranch $private_ranch"
+
+os_test="$1"   # options: centos7, c9s, fedora, rhel7, rhel8, rhel9, rhel9-unsubscribed
+test_case="$2" # options: container, openshift
+if [ -z "$os_test" ] || ! echo "$all_os" | grep -q "$os_test" ; then
+  echo "os_test '$os_test' is not valid"
+  echo "choose one of: $all_os"
+  exit 5
+fi
+
+# container tests vs openshift tests
+if [ -z "$test_case" ] || [ "$test_case" = "container" ] ; then
+  test_case="container"
+  tmt_plan_suffix="-docker"
+  context_suffix=""
+  test_name="test"
+elif [ "$test_case" = openshift ] ; then
+  if [ "$os_test" = "centos7" ] || [ "$os_test" = "rhel7" ] ; then
+    context_suffix=" - OpenShift 3"
+    tmt_plan_suffix="-openshift-3"
+    test_name="test-openshift-3"
+  else
+    context_suffix=" - OpenShift 4"
+    tmt_plan_suffix="-openshift4"
+    test_name="test-openshift-4"
+  fi
+else
+  echo "test_case '$test_case' is not valid"
+  exit 5
+fi
+
+# public vs private ranch
+if echo "$public_ranch" | grep -q "$os_test" ; then
+  api_key="TF_PUBLIC_API_KEY"
+  branch="main"
+  tf_scope="public"
+  tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+else
+  api_key="TF_PRIVATE_API_KEY"
+  branch="master"
+  tf_scope="private"
+  tmt_repo="https://github.com/sclorg/sclorg-testing-farm"
+fi
+
+# variables based on operating system in test
+dockerfile=Dockerfile."$os_test"
+case "$os_test" in
+  "centos7")
+    tmt_plan="centos7"
+    context="CentOS7$context_suffix"
+    dockerfile="Dockerfile"
+    compose="CentOS-7"
+    ;;
+  "c9s")
+    tmt_plan="c9s"
+    context="CentOS Stream 9"
+    compose="CentOS-Stream-9"
+    ;;
+  "fedora")
+    tmt_plan="fedora"
+    context="Fedora"
+    compose="Fedora-latest"
+    ;;
+  "rhel7")
+    tmt_plan="rhel7$tmt_plan_suffix"
+    context="RHEL7$context_suffix"
+    compose="RHEL-7.9-Released"
+    ;;
+  "rhel8")
+    tmt_plan="rhel8$tmt_plan_suffix"
+    context="RHEL8$context_suffix"
+    compose="RHEL-8.6.0-Nightly"
+    ;;
+  "rhel9")
+    tmt_plan="rhel9$tmt_plan_suffix"
+    context="RHEL9$context_suffix"
+    compose="RHEL-9.1.0-Nightly"
+    ;;
+  "rhel9-unsubscribed")
+    os_test="rhel9"
+    dockerfile="Dockerfile.$os_test"
+    tmt_plan="rhel9-unsubscribed-docker"
+    context="RHEL9 - Unsubscribed host"
+    compose="RHEL-9.1.0-Nightly"
+    ;;
+esac
+
+# shellcheck disable=SC2129
+echo "api_key=$api_key"   >> "$GITHUB_OUTPUT"
+echo "branch=$branch"     >> "$GITHUB_OUTPUT"
+echo "tf_scope=$tf_scope" >> "$GITHUB_OUTPUT"
+echo "tmt_repo=$tmt_repo" >> "$GITHUB_OUTPUT"
+echo "os_test=$os_test"   >> "$GITHUB_OUTPUT"
+echo "tmt_plan=$tmt_plan" >> "$GITHUB_OUTPUT"
+echo "context=$context"   >> "$GITHUB_OUTPUT"
+echo "compose=$compose"   >> "$GITHUB_OUTPUT"
+echo "test_name=$test_name" >> "$GITHUB_OUTPUT"
+echo "dockerfile=$dockerfile" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
sclorg-tfaga-wrapper (Software Collections Organization's wrapper for Testing Farm as a GitHub Action)

This wrapper tries to minimize lines of code needed to be written in each
container repository when calling TFaGA.
This should lead to code reduction, dumplicity removal, easier maintaining and adding features.

This action is only for Pull Request comment triggers.

Related: https://github.com/sclorg/nginx-container/pull/235