### PR TITLE
build.sh and tag.sh do not fail if `.git` directory does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,6 @@ Set to true if you want to test container in OpenShift 4 environment.
 `CVP`
 Set to true if you want to test container in Container Validation Pipeline environment.
 
-`NO_GIT_COMMAND`
-Set to true if you want to build and tag container without git command usage.
-
 `clean-hook`
 Append Makefile rules to this variable to make sure additional cleaning actions are run
 when `make clean` is called.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Set to true if you want to test container in OpenShift 4 environment.
 `CVP`
 Set to true if you want to test container in Container Validation Pipeline environment.
 
+`NO_GIT_COMMAND`
+Set to true if you want to build and tag container without git command usage.
+
 `clean-hook`
 Append Makefile rules to this variable to make sure additional cleaning actions are run
 when `make clean` is called.

--- a/build.sh
+++ b/build.sh
@@ -133,7 +133,8 @@ function docker_build_with_version {
   fi
   echo "-> Version ${dir}: building image from '${dockerfile}' ..."
 
-  if [ "${NO_GIT_COMMAND:-"false"}" == "false" ] ; then
+  # We need to check '.git' dir in root directory
+  if [ -d "../.git" ] ; then
     git_version=$(git rev-parse --short HEAD)
     BUILD_OPTIONS+=" --label io.openshift.builder-version=\"${git_version}\""
   fi

--- a/build.sh
+++ b/build.sh
@@ -133,8 +133,10 @@ function docker_build_with_version {
   fi
   echo "-> Version ${dir}: building image from '${dockerfile}' ..."
 
-  git_version=$(git rev-parse --short HEAD)
-  BUILD_OPTIONS+=" --label io.openshift.builder-version=\"${git_version}\""
+  if [ "${NO_GIT_COMMAND:-"false"}" == "false" ] ; then
+    git_version=$(git rev-parse --short HEAD)
+    BUILD_OPTIONS+=" --label io.openshift.builder-version=\"${git_version}\""
+  fi
 
   # Add possibility to use a development repo
   #

--- a/tag.sh
+++ b/tag.sh
@@ -16,7 +16,8 @@ for dir in ${VERSIONS}; do
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID")
   version=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
-  if [ "${NO_GIT_COMMAND:-"false"}" == "false" ] ; then
+  # We need to check '.git' dir in root directory
+  if [ -d "../.git" ] ; then
     commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
     date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
   else

--- a/tag.sh
+++ b/tag.sh
@@ -16,8 +16,12 @@ for dir in ${VERSIONS}; do
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID")
   version=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
-  commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
-  date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
+  if [ "${NO_GIT_COMMAND:-"false"}" == "false" ] ; then
+    commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
+    date_and_hash="${commit_date}-$(git rev-parse --short HEAD)"
+  else
+    date_and_hash="$(date +%Y%m%d%H%M%S)"
+  fi
 
   full_reg_name="$REGISTRY$name"
   echo "-> Tagging image '$IMAGE_ID' as '$full_reg_name:$version' and '$full_reg_name:latest' and '$full_reg_name:$OS' and '$full_reg_name:$date_and_hash'"


### PR DESCRIPTION
In case '.git' directory does not exist in root directory then do not use `git` command for builds and tags.

Closes #324

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>