### PR TITLE
ignore rm of cidfile if it not exist

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -74,7 +74,6 @@ function ct_cleanup() {
     [ -f "$cid_file" ] || continue
     local container
     container=$(cat "$cid_file")
-    rm "$cid_file"
 
     ct_container_exists "$container" || continue
 
@@ -89,6 +88,7 @@ function ct_cleanup() {
       docker logs "$container"
     fi
     docker rm -v "$container"
+    rm -f "$cid_file"
   done
 
   rmdir "$CID_FILE_DIR"


### PR DESCRIPTION
apparently some versions of podman delete also the cidfile during podman rm and some not. That leads to situation that in some OSes (e.g., c9s) the cleaning function fails on podman rm, as the cid_file is removed at that point. This commit fixes this behaviour.

Fixes: https://github.com/sclorg/container-common-scripts/issues/326