### PR TITLE
cleanup: remove CID_FILE_DIR with rm, not rmdir

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -91,7 +91,7 @@ function ct_cleanup() {
     rm -f "$cid_file"
   done
 
-  rmdir "$CID_FILE_DIR"
+  rm -rf "$CID_FILE_DIR"
   exit "${TESTSUITE_RESULT:-0}"
 }
 


### PR DESCRIPTION
Fixes:
```
rmdir: failed to remove '/tmp/tmp.ub7GhquL0h': Directory not empty
make: *** [common/common.mk:105: test] Error 1
Shared connection to 10.31.14.88 closed.
```