### PR TITLE
testlib improvements

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -20,15 +20,16 @@ TESTSUITE_RESULT=0
 OS_CLUSTER_STARTED_BY_TEST=0
 
 function ct_os_cleanup() {
+  local exit_code=$?
   echo "${TEST_SUMMARY:-}"
-  if [ $TESTSUITE_RESULT -eq 0 ] ; then
-    # shellcheck disable=SC2153
-    echo "OpenShift tests for ${IMAGE_NAME} succeeded."
-    exit 0
-  else
+  if [ $TESTSUITE_RESULT -ne 0 ] || [ $exit_code -ne 0 ]; then
     # shellcheck disable=SC2153
     echo "OpenShift tests for ${IMAGE_NAME} failed."
     exit 1
+  else
+    # shellcheck disable=SC2153
+    echo "OpenShift tests for ${IMAGE_NAME} succeeded."
+    exit 0
   fi
 }
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1319,6 +1319,22 @@ ct_check_testcase_result() {
   return "$result"
 }
 
+# ct_update_test_result
+# -----------------------------
+# adds result to the $TEST_SUMMARY variable
+# Argument: test_msg
+# Argument: app_name
+# Argument: test_name
+# Argument: time_diff (optional)
+# Uses: $TEST_SUMMARY - variable for storing test results
+ct_update_test_result() {
+  local test_msg="$1"
+  local app_name="$2"
+  local test_case="$3"
+  local time_diff="${4:-}"
+  printf -v TEST_SUMMARY "%s %s for '%s' %s (%s)\n" "${TEST_SUMMARY:-}" "${test_msg}" "${app_name}" "$test_case" "$time_diff"
+}
+
 # ct_run_tests_from_testset
 # -----------------------------
 # Runs all tests in $TEST_SET, prints result to
@@ -1378,7 +1394,7 @@ ct_run_tests_from_testset() {
       oc project default
     fi
     time_diff=$(ct_timestamp_diff "$time_beg" "$time_end")
-    printf -v TEST_SUMMARY "%s %s for '%s' %s (%s)\n" "${TEST_SUMMARY:-}" "${test_msg}" "${app_name}" "$test_case" "$time_diff"
+    ct_update_test_result "${test_msg}" "${app_name}" "$test_case" "$time_diff"
   done
 }
 

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -17,6 +17,8 @@ else
   return 0
 fi
 
+LINE="=============================================="
+
 # may be redefined in the specific container testfile
 EXPECTED_EXIT_CODE=0
 
@@ -60,10 +62,10 @@ function ct_init() {
 # Uses: $EXPECTED_EXIT_CODE - expected container exit code
 # Uses: $TESTSUITE_RESULT - overall result of all tests
 function ct_cleanup() {
-  echo "--------------------------------------------------"
+  echo "$LINE"
   echo "Cleaning of testing containers and images started."
   echo "It may take a few seconds."
-  echo "--------------------------------------------------"
+  echo "$LINE"
   ct_clean_app_images
   ct_clean_containers
 }
@@ -190,10 +192,10 @@ function ct_clean_containers() {
 # Uses: $TEST_SUMMARY - text info about test-cases
 # Uses: $TESTSUITE_RESULT - overall result of all tests
 function ct_show_results() {
-  echo "==============================================="
+  echo "$LINE"
   #shellcheck disable=SC2153
   echo "Tests were run for image ${IMAGE_NAME}"
-  echo "==============================================="
+  echo "$LINE"
   echo "Test cases results:"
   echo
   echo "${TEST_SUMMARY:-}"
@@ -1143,7 +1145,7 @@ ct_check_latest_imagestreams() {
 ct_show_resources()
 {
   echo
-  echo "==============================================="
+  echo "$LINE"
   echo "Resources info:"
   echo "Memory:"
   free -h
@@ -1152,9 +1154,9 @@ ct_show_resources()
   echo "CPU"
   lscpu
 
-  echo "==============================================="
+  echo "$LINE"
   echo "Image ${IMAGE_NAME} information:"
-  echo "==============================================="
+  echo "$LINE"
   echo "Uncompressed size of the image: $(ct_get_image_size_uncompresseed "${IMAGE_NAME}")"
   echo "Compressed size of the image: $(ct_get_image_size_compresseed "${IMAGE_NAME}")"
   echo

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -109,15 +109,27 @@ ct_build_image_and_parse_id() {
   local ret_val
   local dockerfile
   local command
+  local pid_build
+  local pid_sleep
+  local sleep_time
   log_file="$(mktemp)"
-  ret_val=1
+  sleep_time="10m"
   [ -n "$1" ] && dockerfile="-f $1"
   command="$(echo "docker build --no-cache $dockerfile $2" | tr -d "'")"
+  (
+    $command > "$log_file" 2>&1
+  ) & pid_build=$!
+  (
+    trap 'exit 0' ALRM; sleep "$sleep_time" && kill $pid_build
+  ) & pid_sleep=$!
+  wait $pid_build
+  ret_val=$?
+  kill -s ALRM $pid_sleep 2>/dev/null || ret_val=1
 
-  if $command > "$log_file" 2>&1; then
+  if [ $ret_val -eq 0 ]; then
     APP_IMAGE_ID="$(tail -n 1 "$log_file")"
-    ret_val=0
   fi
+
   cat "$log_file" ; rm -r "$log_file"
   return "$ret_val"
 }

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -91,14 +91,21 @@ ct_build_image_and_parse_id() {
   sleep_time="10m"
   [ -n "$1" ] && dockerfile="-f $1"
   command="$(echo "docker build --no-cache $dockerfile $2" | tr -d "'")"
+  # running command in subshell, the subshell in background, storing pid to variable
   (
     $command > "$log_file" 2>&1
   ) & pid_build=$!
+  # creating second subshell with trap function on ALRM signal
+  # the subshell sleeps for 10m, then kills the first subshell
   (
     trap 'exit 0' ALRM; sleep "$sleep_time" && kill $pid_build
   ) & pid_sleep=$!
+  # waiting for build subshell to finish, either with success, or killed from sleep subshell
   wait $pid_build
   ret_val=$?
+  # send ALRM signal to the sleep subshell, so it exits even in case the 10mins
+  # not yet passed. If the kill was successful (the wait subshell received ALRM signal)
+  # then the build was not finished yet, so the return value is set to 1
   kill -s ALRM $pid_sleep 2>/dev/null || ret_val=1
 
   if [ $ret_val -eq 0 ]; then

--- a/tests/test-lib/run_all_tests
+++ b/tests/test-lib/run_all_tests
@@ -26,20 +26,18 @@ echo "running positive TC that should pass"
 CID_FILE_DIR=$(mktemp -d)
 TEST_SUMMARY=""
 TEST_SET=${TEST_SET_POS} ct_run_tests_from_testset "should_pass" >> /dev/null
-(ct_cleanup >> /dev/null 2>&1)
-if test $? -eq 0 ; then
+if test $TESTSUITE_RESULT -eq 0 ; then
   echo "TC has passed"
 else
   echo "positive TC has failed"
   ret_val=1
 fi
 
-echo "running positive TC that should fail"
+echo "running negative TC that should fail"
 CID_FILE_DIR=$(mktemp -d)
 TEST_SUMMARY=""
 TEST_SET=${TEST_SET_NEG} ct_run_tests_from_testset "should_fail" >> /dev/null
-(ct_cleanup >> /dev/null 2>&1)
-if test $? -eq 1 ; then
+if test $TESTSUITE_RESULT -eq 1 ; then
   echo "TC has failed successfuly"
 else
   echo "negative TC has succeeded, which is bad"


### PR DESCRIPTION
1. kill image build after ten minutes

    The image build is run in subshell, which is killed if does not finish
    after 10 minutes. If the build is finished sooner no action is taken.

    This could however cause problems when sending SIGINT to the test
    process, as trap is not inherited by subshells.

2. use different trap functions for EXIT and SIGINT for container tests

    so when the tests are stopped with SIGINT the final tasks are minimized
    and the waiting time for results is reduced. That means, that image size
    and stats are not shown in this case.

3. OCP tests: examine the exit code in the trap function

    in OCP3 tests we still use set -e for discovering test failure. However,
    if the non-zero exit code is caught by trap function the whole bash ends
    with exit code from the trap function itself and not with the exit code
    with the tests.

    This commit solves the issue by checking what value was returned from
    the testsuite and exits the whole testsuite based on that.

