### PR TITLE
Add .build-args-OS file to let specify build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ Set to true if you want to test container in Container Validation Pipeline envir
 Append Makefile rules to this variable to make sure additional cleaning actions are run
 when `make clean` is called.
 
+Files affecting behaviour
+-------------------------
+The directory with Dockerfiles can optionally include some specific files that affect
+how scripts in this repo work:
+
+`.exclude-<OS>`
+If this file exists, the tooling will not run the build and tests for the specific Dockerfile.
+For example, if `.exclude-rhel7` file exists, the `Dockerfile.rhel7` will not be expected
+in the same directory, build and tests will be skipped.
+Content of the file is not important at this point.
+
+`.devel-repo-<OS>`
+This file is useful if we need to work with RPMs that are not available publically yet.
+Content of the file is not important at this point.
+If such a file exists in the repository, then the building scripts will take a look
+at a correspondent variable, e.g.  DEVEL_REPO_rhel8, and will use the repository file
+defined by that variable.
+That means that definition of the DEVEL_REPO_rhel8 variable is a responsibility of
+the test/CI environment.
+
+`.build-args-<OS>`
+Some images require some specific build options, let them be set in a file specific
+for a Dockerfile. This is useful for example for setting setting capabilities for
+micro images, that install RPMs into an alternative directory and podman versions
+of 4.4.0+ do not set such capabilities by default.
+
 Regression tests
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ the test/CI environment.
 
 `.build-args-<OS>`
 Some images require some specific build options, let them be set in a file specific
-for a Dockerfile. This is useful for example for setting setting capabilities for
+for a Dockerfile. This is useful for example for setting capabilities for
 micro images, that install RPMs into an alternative directory and podman versions
 of 4.4.0+ do not set such capabilities by default.
 

--- a/build.sh
+++ b/build.sh
@@ -177,7 +177,9 @@ function docker_build_with_version {
   # let them be included in the build command.
   # The content of the .build-opts-<OS> will be used as part of the docker build command.
   if [ -f "$build_args_file" ] ; then
-      BUILD_OPTIONS+=" $(cat "$build_args_file")"
+      build_opts_from_file="$(cat "$build_args_file")"
+      echo '⚠️ Be aware, using additional build arguments: ' "${build_opts_from_file}"
+      BUILD_OPTIONS+=" ${build_opts_from_file}"
   fi
 
   pull_image "$dockerfile"

--- a/build.sh
+++ b/build.sh
@@ -122,6 +122,7 @@ function docker_build_with_version {
   local exclude=.exclude-${OS}
   local devel_repo_file=.devel-repo-${OS}
   local devel_repo_var="DEVEL_REPO_$OS"
+  local build_args_file=.build-args-${OS}
   local is_podman
   if [ -e "$exclude" ]; then
     echo "-> $exclude file exists for version $dir, skipping build."
@@ -170,6 +171,13 @@ function docker_build_with_version {
     else
       echo "ERROR: file type not known: $CUSTOM_REPO" >&2
     fi
+  fi
+
+  # If a specific Dockerfile requires some specific build options (like capabilities),
+  # let them be included in the build command.
+  # The content of the .build-opts-<OS> will be used as part of the docker build command.
+  if [ -f "$build_args_file" ] ; then
+      BUILD_OPTIONS+=" $(cat "$build_args_file")"
   fi
 
   pull_image "$dockerfile"


### PR DESCRIPTION
Podman used to set some capabilities by default, but does not any more with version 4.4.0 and newer. These capabilities need to be set for being able to build micro images that install RPMs into an alternative path in the Dockerfile. Introducing .build-args-OS file means we will be able to specify some arguments to docker build command for each Dockerfile specifically, for example specify capabilities for the micro images.