### PR TITLE
Show resources only in non-debug mode

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -227,7 +227,7 @@ function ct_trap_on_exit() {
   # if any is added in the future.
   echo "Tests finished with EXIT=$exit_code"
   [ $exit_code -eq 0 ] && exit_code="${TESTSUITE_RESULT:-0}"
-  ct_show_resources
+  [ -n "${DEBUG:-}" ] || ct_show_resources
   ct_cleanup
   ct_show_results
   exit $exit_code


### PR DESCRIPTION
It may slow down debugging the tests, so let's not show resources whatsoever when in DEBUG mode

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
