### PR TITLE
Do not delete secrets with parametr --all

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -407,7 +407,7 @@ function ct_os_delete_project() {
 # Deletes all objects within the project.
 # Handy when we have one project and want to run more tests.
 function ct_delete_all_objects() {
-  local objects="bc builds dc is isimage istag po pvc rc routes secrets svc"
+  local objects="bc builds dc is isimage istag po pvc rc routes svc"
   if [ "${CVP:-0}" -eq "1" ]; then
     echo "Testing in CVP environment. No need to delete isimage and istag in OpenShift project. This is done by CVP pipeline"
     objects="bc builds dc po pvc rc routes"


### PR DESCRIPTION
This pull request disables deleting all  'secrets' and 'services' over all namespaces. Secrets are used for communication with kubernetes, docker etc.
