### PR TITLE
Let's build and tag only SINGLE_VERSION as it is supported by CI.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@
 #
 # OS - Specifies distribution - "rhel7", "rhel8", "rhel9", "centos7", "c8s", "c9s" or "fedora"
 # VERSION - Specifies the image version - (must match with subdirectory in repo)
+# SINGLE_VERSION - Specifies the image version - (must match with subdirectory in repo)
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
 
 set -eE
@@ -200,6 +201,14 @@ function docker_build_with_version {
 # Versions are stored in subdirectories. You can specify VERSION variable
 # to build just one single version. By default we build all versions
 dirs=${VERSION:-$VERSIONS}
+if [ -n "${SINGLE_VERSION:-}" ]; then
+  if [ "$SINGLE_VERSION" != "$VERSION" ]; then
+    echo "Skipping build for $VERSION. SINGLE_VERSION is defined $SINGLE_VERSION and does not equal to $VERSION."
+    exit 0
+  fi
+  dirs=$SINGLE_VERSION
+fi
+echo "Built versions are: $dirs"
 
 for dir in ${dirs}; do
   pushd "${dir}" > /dev/null

--- a/tag.sh
+++ b/tag.sh
@@ -12,6 +12,12 @@ set -eE
 trap 'echo "errexit on line $LINENO, $0" >&2' ERR
 
 [ -n "${DEBUG:-}" ] && set -x
+# This adds backwards compatibility if only single version needs to be tagged
+# In CI we would like to test single version but VERSIONS= means, that nothing is tested
+# make tag TARGET=<OS> VERSIONS=<something> ... checks single version for CLI
+# make tag TARGET=<OS> SINGLE_VERSION=<something> ... checks single version from Testing Farm
+VERSIONS=${SINGLE_VERSION:-$VERSIONS}
+echo "Tagged versions are: $VERSIONS"
 
 for dir in ${VERSIONS}; do
   [ ! -e "${dir}/.image-id" ] && echo "-> Image for version $dir not built, skipping tag." && continue


### PR DESCRIPTION
Let's build and tag only SINGLE_VERSION as it is supported by CI.

Our CI system now supports testing only SINGLE_VERSION.
We do not need to build and tag all other versions.

This pull request supports building and tagging specific
versions.
