### PR TITLE
Don't print the error message on multispec exit code 2

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -37,7 +37,10 @@ def run_distgen(
     try:
         check_output(cmd)
     except CalledProcessError as e:
-        print("[ERROR] distgen failed:", e)
+        # Exit code 2 is a special code for non existing matrix combinations
+        # It's not an actual error, hence don't print out its error message
+        if e.returncode != 2:
+            print("[ERROR] distgen failed:", e)
 
 
 def get_version_distro_mapping(


### PR DESCRIPTION
For non-existing and not expected matrix combinations generator produced a loud message that looked like a genuine error.

```
[ERROR] distgen failed: Command '['dg', '--multispec', 'specs/multispec.yml',
'--template', 'src/Dockerfile.template', '--distro', 'centos-7-x86_64.yaml',
'--multispec-selector', 'version=3.11', '--output', '3.11/Dockerfile.centos7']'
returned non-zero exit status 2.
```

For exit code 2 the message is now supressed.
Related: https://github.com/sclorg/s2i-python-container/issues/594

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
