### PR TITLE
Build and tag the non-minimal variant as well

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -207,6 +207,14 @@ if [ -n "${SINGLE_VERSION:-}" ]; then
     exit 0
   fi
   dirs=$SINGLE_VERSION
+  if [[ "${SINGLE_VERSION}" == *"minimal"* ]]; then
+    echo "Adding ${SINGLE_VERSION//-minimal/} because it might be needed for testing $SINGLE_VERSION."
+    dirs="$dirs ${SINGLE_VERSION//-minimal/}"
+  fi
+  if [[ "${SINGLE_VERSION}" == *"micro"* ]]; then
+    echo "Adding ${SINGLE_VERSION//-micro/} because it might be needed for testing $SINGLE_VERSION."
+    dirs="$dirs ${SINGLE_VERSION//-micro/}"
+  fi
 fi
 echo "Built versions are: $dirs"
 

--- a/tag.sh
+++ b/tag.sh
@@ -17,6 +17,14 @@ trap 'echo "errexit on line $LINENO, $0" >&2' ERR
 # make tag TARGET=<OS> VERSIONS=<something> ... checks single version for CLI
 # make tag TARGET=<OS> SINGLE_VERSION=<something> ... checks single version from Testing Farm
 VERSIONS=${SINGLE_VERSION:-$VERSIONS}
+if [[ "${SINGLE_VERSION}" == *"minimal"* ]]; then
+  echo "Adding ${SINGLE_VERSION//-minimal/} because it might be needed for testing $SINGLE_VERSION."
+  VERSIONS="$VERSIONS ${SINGLE_VERSION//-minimal/}"
+fi
+if [[ "${SINGLE_VERSION}" == *"micro"* ]]; then
+  echo "Adding ${SINGLE_VERSION//-micro/} because it might be needed for testing $SINGLE_VERSION."
+  VERSIONS="$VERSIONS ${SINGLE_VERSION//-micro/}"
+fi
 echo "Tagged versions are: $VERSIONS"
 
 for dir in ${VERSIONS}; do


### PR DESCRIPTION
Without having the non-minimal image build and tagged, the image might be missing (sometimes it's not available in the repository yet, for new versions specifically), so let's build and tag it as well.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
