### PR TITLE
add support for running upstream testsuites

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -67,5 +67,12 @@ for dir in ${VERSIONS}; do
     fi
   fi
 
+  if [ -n "${TEST_UPSTREAM}" ]; then
+    if [[ -x test/run-upstream ]]; then
+      VERSION=$dir test/run-upstream
+    else
+      echo "-> Upstream tests are not present, skipping"
+    fi
+  fi
   popd > /dev/null
 done

--- a/tests/failures/check/v0/Dockerfile.c9s
+++ b/tests/failures/check/v0/Dockerfile.c9s
@@ -1,0 +1,2 @@
+FROM quay.io/sclorg/s2i-core-c9s
+LABEL name=test-image


### PR DESCRIPTION
The nodejs container needs to implement new test target, so that the client upstream testsuites can be run separately from other tests. This commit is for support of this new feature.

Setting as draft for now.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
