### PR TITLE
test c9s compose instead of deprecated centos7

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         container-to-test: ["postgresql-container", "nginx-container", "s2i-perl-container", "s2i-python-container", "s2i-base-container" ]
-        os: ["fedora", "centos7", "rhel7", "rhel8", "rhel9"]
+        os: ["fedora", "c9s", "rhel7", "rhel8", "rhel9"]
 
     if: |
       github.event.issue.pull_request
@@ -32,7 +32,7 @@ jobs:
           branch="master"
           tf_scope="private"
           tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-          if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "centos7" ]; then
+          if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "c9s" ]; then
             api_key=${{ secrets.TF_PUBLIC_API_KEY }}
             branch="main"
             tf_scope="public"
@@ -42,9 +42,9 @@ jobs:
               context="Fedora"
               tmt_plan="fedora"
             else
-              compose="CentOS-7"
-              context="CentOS7"
-              tmt_plan="centos7"
+              compose="CentOS-Stream-9"
+              context="CentOS Stream 9"
+              tmt_plan="c9s"
             fi
           else
             if [ "${{ matrix.os }}" == "rhel7" ]; then


### PR DESCRIPTION
We no longer test centos7 compose in any of our images, thus it does not make sense here anymore.

@phracek could you please take a look at this PR, to check if I did not miss anything? Thanks.
