### PR TITLE
Add support docker_args for `ct_build_image_and_parse_id`

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1213,7 +1213,7 @@ ct_test_app_dockerfile() {
   local app_url=$2
   local expected_text=$3
   local app_dir=$4 # this is a directory that must match with the name in the Dockerfile
-  local docker_args
+  local build_args=${5:-""}
   local port=8080
   local app_image_name=myapp
   local ret

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1253,7 +1253,6 @@ ct_test_app_dockerfile() {
       return 1
     fi
   fi
-  [ -n "$5" ] && docker_args=" $5"
   echo "Building '${app_image_name}' image using docker build"
   if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." "$build_args"; then
     echo "ERROR: The image cannot be built from ${dockerfile} and application ${app_url}."

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1255,7 +1255,7 @@ ct_test_app_dockerfile() {
   fi
   [ -n "$5" ] && docker_args=" $5"
   echo "Building '${app_image_name}' image using docker build"
-  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." "$docker_args"; then
+  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." "$build_args"; then
     echo "ERROR: The image cannot be built from ${dockerfile} and application ${app_url}."
     echo "Terminating the Dockerfile build."
     return 1

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1213,7 +1213,8 @@ ct_test_app_dockerfile() {
   local app_url=$2
   local expected_text=$3
   local app_dir=$4 # this is a directory that must match with the name in the Dockerfile
-  local port=${5:-8080}
+  local docker_args
+  local port=8080
   local app_image_name=myapp
   local ret
   local cname=app_dockerfile
@@ -1252,9 +1253,9 @@ ct_test_app_dockerfile() {
       return 1
     fi
   fi
-
+  [ -n "$5" ] && docker_args=" $5"
   echo "Building '${app_image_name}' image using docker build"
-  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." ; then
+  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." "$docker_args"; then
     echo "ERROR: The image cannot be built from ${dockerfile} and application ${app_url}."
     echo "Terminating the Dockerfile build."
     return 1

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1207,7 +1207,7 @@ ct_get_uid_from_image()
 # Argument: app_url - git or local URI with a testing application, supports "@" to indicate a different branch
 # Argument: body_regexp - PCRE regular expression that must match the response body
 # Argument: app_dir - name of the application directory that is used in the Dockerfile
-# Argument: port - Optional port number (default: 8080)
+# Argument: build_args - build args that will be used for building an image
 ct_test_app_dockerfile() {
   local dockerfile=$1
   local app_url=$2


### PR DESCRIPTION
This commit was tested on two containers.
nginx-container and s2i-nodejs-container.

nginx-container uses https://github.com/sclorg/nginx-container/blob/2ba264983b1236c6299eb83c62e4db9f40959f36/test/run#L418 s2i-nodejs-container pull request is here: https://github.com/sclorg/s2i-nodejs-container/pull/421

In whole SCLORG organization https://github.com/search?q=org%3Asclorg++ct_test_app_dockerfile&type=code

It is not used port as a parameter at all, therefore removing it from function as a parameter makes sense.

nginx-container test status:
```
Running test run_dockerfiles_test (starting at 2024-03-12 04:14:16-04:00) ...
-----------------------------------------------
Using this Dockerfile:
FROM ubi8/nginx-122:1

ENV NGINX_VERSION=1.22

ADD nginx-container/examples/1.22/test-app/nginx.conf "${NGINX_CONF_PATH}"
ADD nginx-container/examples/1.22/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
ADD nginx-container/examples/1.22/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
ADD nginx-container/examples/1.22/test-app/*.html ./

CMD nginx -g "daemon off;"
Cloning into 'nginx-container'...
remote: Enumerating objects: 2913, done.
remote: Counting objects: 100% (929/929), done.
remote: Compressing objects: 100% (210/210), done.
remote: Total 2913 (delta 780), reused 782 (delta 716), pack-reused 1984
Receiving objects: 100% (2913/2913), 526.15 KiB | 13.15 MiB/s, done.
Resolving deltas: 100% (1760/1760), done.
Building 'myapp' image using docker build
STEP 1/7: FROM ubi8/nginx-122:1
STEP 2/7: ENV NGINX_VERSION=1.22
--> e56b32fe6508
STEP 3/7: ADD nginx-container/examples/1.22/test-app/nginx.conf "${NGINX_CONF_PATH}"
--> 73028c318591
STEP 4/7: ADD nginx-container/examples/1.22/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
--> d9c1aaa92cfa
STEP 5/7: ADD nginx-container/examples/1.22/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
--> bf1bdc45252b
STEP 6/7: ADD nginx-container/examples/1.22/test-app/*.html ./
--> d1dcad6766c7
STEP 7/7: CMD nginx -g "daemon off;"
COMMIT myapp
--> 6fb02d0904c2
Successfully tagged localhost/myapp:latest
6fb02d0904c2d46c02e57471abf4c48861a3d6f53efd6e9cd6d005b1076009d0
b8c9e2de19e5e4b6f8631520d4be7d87f91635a9965d37cda55286a028c26b1b
Waiting for myapp to start
  Testing the HTTP(S) response for <http://10.88.0.47:8080>
Trying to connect ... 1
b8c9e2de19e5e4b6f8631520d4be7d87f91635a9965d37cda55286a028c26b1b
```

s2i-nodejs-container test status:
```
Running test test_check_build_using_dockerfile (starting at 2024-03-12 04:25:09-04:00) ...
-----------------------------------------------

[INFO] Check building using a Dockerfile...

Using this Dockerfile:
FROM ubi8/nodejs-20:1

ADD app-src .

USER 0
RUN fix-permissions ./
USER 1001

RUN npm install

CMD npm run -d start
Cloning into 'app-src'...
remote: Enumerating objects: 782, done.
remote: Counting objects: 100% (100/100), done.
remote: Compressing objects: 100% (69/69), done.
remote: Total 782 (delta 32), reused 84 (delta 25), pack-reused 682
Receiving objects: 100% (782/782), 759.52 KiB | 15.50 MiB/s, done.
Resolving deltas: 100% (299/299), done.
Docker params are  --ulimit nofile=4096:4096
Building 'myapp' image using docker build
STEP 1/7: FROM ubi8/nodejs-20:1
STEP 2/7: ADD app-src .
--> 36c4b248c26b
STEP 3/7: USER 0
--> a46d8b1d8f63
STEP 4/7: RUN fix-permissions ./
--> c087f8a238c2
STEP 5/7: USER 1001
--> dbb76744f0be
STEP 6/7: RUN npm install
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated jose@1.28.2: this version is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

added 785 packages, and audited 786 packages in 28s

107 packages are looking for funding
  run `npm fund` for details

14 vulnerabilities (12 moderate, 1 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm notice
npm notice New minor version of npm available! 10.2.4 -> 10.5.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.5.0>
npm notice Run `npm install -g npm@10.5.0` to update!
npm notice
--> 5797613b4e3d
STEP 7/7: CMD npm run -d start
```

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
