### PR TITLE
Typo in forwarding parameters

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1254,7 +1254,7 @@ ct_test_app_dockerfile() {
     fi
   fi
   echo "Building '${app_image_name}' image using docker build"
-  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} ." "$build_args"; then
+  if ! ct_build_image_and_parse_id "" "-t ${app_image_name} . $build_args"; then
     echo "ERROR: The image cannot be built from ${dockerfile} and application ${app_url}."
     echo "Terminating the Dockerfile build."
     return 1


### PR DESCRIPTION
ct_build_image_and_parse_id consumes only two parameters

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
