### PR TITLE
Add build_args also to `ct_s2i_build_as_df` function.

### DIFF
--- a/test-lib.sh
+++ b/test-lib.sh
@@ -813,7 +813,7 @@ ct_get_public_image_name() {
   elif [ "$os" == "rhel9" ]; then
     public_image_name=$registry/rhel9/$base_image_name-${version//./}
   elif [ "$os" == "centos7" ]; then
-    public_image_name=$registry/centos7/$base_image_name-${version//./}-centos7
+    public_image_name=$registry/centos7/$base_image_name-${version//./}-centos7:centos7
   elif [ "$os" == "c8s" ]; then
     public_image_name=$registry/sclorg/$base_image_name-${version//./}-c8s
   elif [ "$os" == "c9s" ]; then

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -989,6 +989,8 @@ EOF
     # Check if -v parameter is present in s2i_args and add it into docker build command
     read -ra mount_options <<< "$(echo "$s2i_args" | grep -o -e '\(-v\)[[:space:]]\.*\S*' || true)"
 
+    # Check if s2i_args contains --ulimit
+    # if so, add it into docker build command. The format is like --ulimit nofile=4096:4096
     echo "$s2i_args" | grep -q '\--ulimit' && build_args=$(echo "$s2i_args" | grep -o -e '\--ulimit[[:space:]]\S*\w=*')
     # Run the build and tag the result
     ct_build_image_and_parse_id "$df_name" "${mount_options[*]+${mount_options[*]}} -t $dst_image . $build_args"

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -883,6 +883,9 @@ ct_s2i_usage()
 # ct_s2i_build_as_df APP_PATH SRC_IMAGE DST_IMAGE [S2I_ARGS]
 # ----------------------------
 # Create a new s2i app image from local sources in a similar way as source-to-image would have used.
+# This function is wrapper for ct_s2i_build_as_df_build_args in case user do not want to add build args
+# This function is used in all https://github.com/sclorg/*-container test cases and we do not
+# want to break functionality
 # Argument: APP_PATH - local path to the app sources to be used in the test
 # Argument: SRC_IMAGE - image to be used as a base for the s2i build
 # Argument: DST_IMAGE - image name to be used during the tagging of the s2i build result
@@ -898,7 +901,7 @@ ct_s2i_build_as_df()
     ct_s2i_build_as_df_build_args "$app_path" "$src_image" "$dst_image" "" "$s2i_args"
 }
 
-# ct_s2i_build_as_df_build_args APP_PATH SRC_IMAGE DST_IMAGE [S2I_ARGS]
+# ct_s2i_build_as_df_build_args APP_PATH SRC_IMAGE DST_IMAGE BUILD_ARGS [S2I_ARGS]
 # ----------------------------
 # Create a new s2i app image from local sources in a similar way as source-to-image would have used.
 # Argument: APP_PATH - local path to the app sources to be used in the test

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -902,6 +902,7 @@ ct_s2i_build_as_df()
     local incremental=false
     local mount_options=()
     local id_file
+    local build_args=""
 
     # Run the entire thing inside a subshell so that we do not leak shell options outside of the function
     (
@@ -988,8 +989,9 @@ EOF
     # Check if -v parameter is present in s2i_args and add it into docker build command
     read -ra mount_options <<< "$(echo "$s2i_args" | grep -o -e '\(-v\)[[:space:]]\.*\S*' || true)"
 
+    echo "$s2i_args" | grep -q '\--ulimit' && build_args=$(echo "$s2i_args" | grep -o -e '\--ulimit[[:space:]]\S*\w=*')
     # Run the build and tag the result
-    ct_build_image_and_parse_id "$df_name" "${mount_options[*]+${mount_options[*]}} -t $dst_image ."
+    ct_build_image_and_parse_id "$df_name" "${mount_options[*]+${mount_options[*]}} -t $dst_image . $build_args"
     #shellcheck disable=SC2181
     if [ "$?" -ne 0 ]; then
       echo "  ERROR: Failed to to build $df_name" >&2

--- a/tests/failures/check/v0/Dockerfile
+++ b/tests/failures/check/v0/Dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/centos7/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7:centos7
 LABEL name=test-image

--- a/tests/test-lib/image_availability
+++ b/tests/test-lib/image_availability
@@ -5,25 +5,25 @@ set -e
 . test-lib.sh
 
 # This should succeed
-if ! ct_pull_image quay.io/centos7/ruby-27-centos7; then
+if ! ct_pull_image quay.io/centos7/ruby-27-centos7:centos7; then
   echo "image_availability test failed"
   false
 fi
 
 # This should fail
-if ct_pull_image quay.io/centos7/ruby-24-centos7 false 1; then
+if ct_pull_image quay.io/centos7/ruby-24-centos7:centos7 false 1; then
   echo "image_availability test failed"
   false
 fi
 
 # This should succeed
-if ! ct_check_image_availability quay.io/centos7/ruby-27-centos7; then
+if ! ct_check_image_availability quay.io/centos7/ruby-27-centos7:centos7; then
   echo "check_image_availability test failed"
   false
 fi
 
 # This should fail
-if ct_check_image_availability quay.io/centos7/ruby-24-centos7; then
+if ct_check_image_availability quay.io/centos7/ruby-24-centos7:centos7; then
   echo "check_image_availability test failed"
   false
 fi

--- a/tests/test-lib/public_image_name
+++ b/tests/test-lib/public_image_name
@@ -5,7 +5,7 @@ set -e
 . test-lib.sh
 
 combinations="rhel7:registry.redhat.io/rhscl/postgresql-10-rhel7
-centos7:quay.io/centos7/postgresql-10-centos7
+centos7:quay.io/centos7/postgresql-10-centos7:centos7
 rhel8:registry.redhat.io/rhel8/postgresql-10
 "
 


### PR DESCRIPTION
Add build_args also to `ct_s2i_build_as_df` function.
We have to functions to build image. This one and `ct_test_app_dockerfile`

In case of --ulimit is defined in s2i_args variable we will add this parameter to docker/podman command line.

This pull request blocks https://github.com/sclorg/s2i-nodejs-container/pull/425.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
