### PR TITLE
Migrate OCP4 tests to MP+

### DIFF
--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -115,7 +115,7 @@ function ct_os_login_external_registry() {
   OCP4_REGISTER="$INTERNAL_IMAGE_REGISTRY"
   # shellcheck disable=SC2034
   for i in $(seq 12) ; do
-    # shellcheck disable=SC2015
+    # shellcheck disable=SC2153
     robot_token=$(cat "${ROBOT_TOKEN}")
     robot_username=$(cat "${ROBOT_NAME}")
     # shellcheck disable=SC2015


### PR DESCRIPTION
This pull request adds support for testing https://github.com/sclorg containers in MP+ (shared cluster) instead of our own OCP4 cluster installed on RHOS.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
