### PR TITLE
deprecate c8s images, as EOL for c8s is 31th of May 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Dockerfile for the scripts to know which versions to build.
 
 `OS`
 OS version you want to build the images for. Currently the scripts are able to build for
-centos (default), centos6, c8s, c9s, rhel7, rhel8, rhel9, and fedora.
+centos (default), centos6, c9s, rhel7, rhel8, rhel9, and fedora.
 
 `SKIP_SQUASH`
 When set to 1 the build script will skip the squash phase of the build.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This script is used to build the OpenShift Docker images.
 #
-# OS - Specifies distribution - "rhel7", "rhel8", "rhel9", "centos7", "c8s", "c9s" or "fedora"
+# OS - Specifies distribution - "rhel7", "rhel8", "rhel9", "centos7", "c9s" or "fedora"
 # VERSION - Specifies the image version - (must match with subdirectory in repo)
 # SINGLE_VERSION - Specifies the image version - (must match with subdirectory in repo)
 # VERSIONS - Must be set to a list with possible versions (subdirectories)

--- a/common.mk
+++ b/common.mk
@@ -49,10 +49,6 @@ else ifeq ($(TARGET),fedora)
 else ifeq ($(TARGET),centos6)
 	OS := centos6
 	DOCKERFILE ?= Dockerfile.centos6
-else ifeq ($(TARGET),c8s)
-	OS := c8s
-	DOCKERFILE ?= Dockerfile.c8s
-	REGISTRY := quay.io/
 else ifeq ($(TARGET),c9s)
 	OS := c9s
 	DOCKERFILE ?= Dockerfile.c9s

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -814,8 +814,6 @@ ct_get_public_image_name() {
     public_image_name=$registry/rhel9/$base_image_name-${version//./}
   elif [ "$os" == "centos7" ]; then
     public_image_name=$registry/centos7/$base_image_name-${version//./}-centos7:centos7
-  elif [ "$os" == "c8s" ]; then
-    public_image_name=$registry/sclorg/$base_image_name-${version//./}-c8s
   elif [ "$os" == "c9s" ]; then
     public_image_name=$registry/sclorg/$base_image_name-${version//./}-c9s
   fi

--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,7 @@ for dir in ${VERSIONS}; do
   # Kept also IMAGE_NAME as some tests might still use that.
   IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$IMAGE_VERSION"
     # shellcheck disable=SC2268
-  if [ "${OS}" == "centos7" ] || [ "${OS}" == "c9s" ] || [ "${OS}" == "fedora" ] || [ "${OS}" == "c8s" ]; then
+  if [ "${OS}" == "centos7" ] || [ "${OS}" == "c9s" ] || [ "${OS}" == "fedora" ]; then
     export IMAGE_NAME="$REGISTRY$IMAGE_NAME"
   else
     export IMAGE_NAME


### PR DESCRIPTION
This PR can be merged after all of PR against containers repositories are merged[1].



[1] https://github.com/sclorg/container-common-scripts/issues/362
