### PR TITLE
Show all imagestreams in imagestream file

### DIFF
--- a/show_all_imagestreams.py
+++ b/show_all_imagestreams.py
@@ -1,0 +1,64 @@
+#!/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import os
+
+from pathlib import Path
+from typing import Dict, Any
+
+IMAGESTREAMS_DIR: str = "imagestreams"
+
+
+class ShowAllImageStreams(object):
+    version: str = ""
+
+    def __init__(self):
+        pass
+
+    def load_json_file(self, filename: Path) -> Any:
+        with open(str(filename)) as f:
+            data = json.load(f)
+            isinstance(data, Dict)
+            return data
+
+    def show_all_imagestreams(self):
+        p = Path(".")
+        json_files = p.glob(f"{IMAGESTREAMS_DIR}/*.json")
+        if not json_files:
+            print(f"No json files present in {IMAGESTREAMS_DIR}.")
+            return 0
+        for f in json_files:
+            if os.environ.get("TARGET") in ("rhel7", "centos7") and "aarch64" in str(f):
+                print("Imagestream aarch64 is not supported on rhel7")
+                continue
+            json_dict = self.load_json_file(f)
+            print(f"Tags in the image stream {f}:")
+            for tag in json_dict["spec"]["tags"]:
+                print(f"- {tag['name']} -> {tag['from']['name']}")
+
+
+if __name__ == "__main__":
+    isc = ShowAllImageStreams()
+    isc.show_all_imagestreams()

--- a/show_all_imagestreams.py
+++ b/show_all_imagestreams.py
@@ -24,6 +24,7 @@
 
 import json
 import os
+import sys
 
 from pathlib import Path
 from typing import Dict, Any
@@ -32,18 +33,13 @@ IMAGESTREAMS_DIR: str = "imagestreams"
 
 
 class ShowAllImageStreams(object):
-    version: str = ""
-
-    def __init__(self):
-        pass
-
     def load_json_file(self, filename: Path) -> Any:
         with open(str(filename)) as f:
             data = json.load(f)
             isinstance(data, Dict)
             return data
 
-    def show_all_imagestreams(self):
+    def show_all_imagestreams(self) -> int:
         p = Path(".")
         json_files = p.glob(f"{IMAGESTREAMS_DIR}/*.json")
         if not json_files:
@@ -57,8 +53,9 @@ class ShowAllImageStreams(object):
             print(f"Tags in the image stream {f}:")
             for tag in json_dict["spec"]["tags"]:
                 print(f"- {tag['name']} -> {tag['from']['name']}")
+        return 0
 
 
 if __name__ == "__main__":
     isc = ShowAllImageStreams()
-    isc.show_all_imagestreams()
+    sys.exit(isc.show_all_imagestreams())

--- a/show_all_imagestreams.py
+++ b/show_all_imagestreams.py
@@ -58,4 +58,4 @@ class ShowAllImageStreams(object):
 
 if __name__ == "__main__":
     isc = ShowAllImageStreams()
-    sys.exit(isc.show_all_imagestreams())
+    isc.show_all_imagestreams()

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -1126,6 +1126,7 @@ ct_check_image_availability() {
   fi
 }
 
+
 # ct_check_latest_imagestreams
 # -----------------------------
 # Check if the latest version present in Makefile in the variable VERSIONS
@@ -1147,9 +1148,11 @@ ct_check_latest_imagestreams() {
     [ -f "$latest_version/.exclude-$OS" ] && latest_version=$(grep '^VERSIONS' Makefile | rev | cut -d ' ' -f 2 | rev )
     # Only test the imagestream once, when the version matches
     # ignore the SC warning, $VERSION is always available
+
+    test_lib_dir=$(dirname "$(readlink -f "$0")")
+    python3 "${test_lib_dir}/show_all_imagestreams.py"
     # shellcheck disable=SC2153
     if [ "$latest_version" == "$VERSION" ]; then
-      test_lib_dir=$(dirname "$(readlink -f "$0")")
       python3 "${test_lib_dir}/check_imagestreams.py" "$latest_version"
     else
       echo "Image version $VERSION is not latest, skipping ct_check_latest_imagestreams"

--- a/tests/check_imagestreams.sh
+++ b/tests/check_imagestreams.sh
@@ -8,7 +8,8 @@ show_all_imagestreams=$(dirname "$(readlink -f "$0")")/../show_all_imagestreams.
 test $? -eq 1
 "${PYTHON-python3}" "$check_imagestreams" "2.4"
 test $? -eq 0
-echo "Check full is output"
+
+echo "This tests check if 'show_all_imagestreams.py' returns proper output"
 output=$("${PYTHON-python3}" "$show_all_imagestreams")
 test "${output#*"- latest -> 2.4"}" != "$output" && echo "latest found in the output"
 test "${output#*"- 2.4 -> registry.redhat.io/rhscl/httpd-24-rhel7"}" != "$output" && echo "2.4 found in the output"

--- a/tests/check_imagestreams.sh
+++ b/tests/check_imagestreams.sh
@@ -3,7 +3,12 @@
 set -x
 
 check_imagestreams=$(dirname "$(readlink -f "$0")")/../check_imagestreams.py
+show_all_imagestreams=$(dirname "$(readlink -f "$0")")/../show_all_imagestreams.py
 "${PYTHON-python3}" "$check_imagestreams" "2.5"
 test $? -eq 1
 "${PYTHON-python3}" "$check_imagestreams" "2.4"
 test $? -eq 0
+echo "Check full is output"
+output=$("${PYTHON-python3}" "$show_all_imagestreams")
+test "${output#*"- latest -> 2.4"}" != "$output" && echo "latest found in the output"
+test "${output#*"- 2.4 -> registry.redhat.io/rhscl/httpd-24-rhel7"}" != "$output" && echo "2.4 found in the output"


### PR DESCRIPTION
This pull request shows all tags in all imagestream json files.

It replaces this pull request https://github.com/sclorg/container-common-scripts/pull/256


<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
