### PR TITLE
Support for building and testing RHEL10

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Dockerfile for the scripts to know which versions to build.
 
 `OS`
 OS version you want to build the images for. Currently the scripts are able to build for
-centos (default), c9s, c10s, rhel8, rhel9, and fedora.
+centos (default), c9s, c10s, rhel8, rhel9, rhel10, and fedora.
 
 `SKIP_SQUASH`
 When set to 1 the build script will skip the squash phase of the build.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This script is used to build the OpenShift Docker images.
 #
-# OS - Specifies distribution - "rhel8", "rhel9", "c9s", "c10s" or "fedora"
+# OS - Specifies distribution - "rhel8", "rhel9", "rhel10", "c9s", "c10s" or "fedora"
 # VERSION - Specifies the image version - (must match with subdirectory in repo)
 # SINGLE_VERSION - Specifies the image version - (must match with subdirectory in repo)
 # VERSIONS - Must be set to a list with possible versions (subdirectories)

--- a/common.mk
+++ b/common.mk
@@ -38,6 +38,9 @@ ifeq ($(TARGET),rhel8)
 else ifeq ($(TARGET),rhel9)
 	OS := rhel9
 	DOCKERFILE ?= Dockerfile.rhel9
+else ifeq ($(TARGET),rhel10)
+	OS := rhel10
+	DOCKERFILE ?= Dockerfile.rhel10
 else ifeq ($(TARGET),fedora)
 	OS := fedora
 	DOCKERFILE ?= Dockerfile.fedora

--- a/test-lib-remote-openshift.sh
+++ b/test-lib-remote-openshift.sh
@@ -86,6 +86,8 @@ function ct_os_tag_image_for_cvp() {
     tag="-el8"
   elif [ "${OS}" == "rhel9" ]; then
     tag="-el9"
+  elif [ "${OS}" == "rhel10" ]; then
+    tag="-el10"
   else
     echo "Only RHEL images are supported."
     return

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -794,6 +794,8 @@ ct_get_public_image_name() {
     public_image_name=$registry/rhel8/$base_image_name-${version//./}
   elif [ "$os" == "rhel9" ]; then
     public_image_name=$registry/rhel9/$base_image_name-${version//./}
+  elif [ "$os" == "rhel10" ]; then
+    public_image_name=$registry/rhel10/$base_image_name-${version//./}
   elif [ "$os" == "c9s" ]; then
     public_image_name=$registry/sclorg/$base_image_name-${version//./}-c9s
   elif [ "$os" == "c10s" ]; then

--- a/tests/failures/check/v0/Dockerfile.rhel10
+++ b/tests/failures/check/v0/Dockerfile.rhel10
@@ -1,0 +1,3 @@
+FROM ubi9/s2i-core
+## ubi10/s2i-core does not exist let's use ubi9/s2i-core
+LABEL name=test-image


### PR DESCRIPTION
This pull request adds support for building and testing RHEL10 containers.

The issue is blocked by https://github.com/sclorg/tfaga-wrapper/pull/37































































































































































<!-- issue-commentator = {"comment-id":"2580131600"} -->











































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2580099142","data":[{"id":"c6c57f03-9b2c-4a79-a017-e53cd8879e6c","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":983.57023,"created":"2025-01-09T13:43:50.345472","updated":"2025-01-09T13:43:50.345485","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c6c57f03-9b2c-4a79-a017-e53cd8879e6c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c6c57f03-9b2c-4a79-a017-e53cd8879e6c/pipeline.log\">pipeline</a>"]},{"id":"34bbbca7-abaa-4188-adf2-cf14c88c48c2","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":866.053363,"created":"2025-01-09T13:43:50.848054","updated":"2025-01-09T13:43:50.848062","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/34bbbca7-abaa-4188-adf2-cf14c88c48c2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/34bbbca7-abaa-4188-adf2-cf14c88c48c2/pipeline.log\">pipeline</a>"]},{"id":"65c7d61b-8e05-4de8-b66d-ea65ad41100b","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1471.635084,"created":"2025-01-09T13:43:03.733912","updated":"2025-01-09T13:43:03.733919","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/65c7d61b-8e05-4de8-b66d-ea65ad41100b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/65c7d61b-8e05-4de8-b66d-ea65ad41100b/pipeline.log\">pipeline</a>"]},{"id":"8528b71d-f16c-4156-8a8c-d0c4d5f571c0","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":1007.336504,"created":"2025-01-09T13:43:02.053552","updated":"2025-01-09T13:43:02.053561","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8528b71d-f16c-4156-8a8c-d0c4d5f571c0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8528b71d-f16c-4156-8a8c-d0c4d5f571c0/pipeline.log\">pipeline</a>"]},{"id":"03a1749f-4df0-4837-bc70-b1de8aa663cc","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":731.095822,"created":"2025-01-09T13:43:02.268229","updated":"2025-01-09T13:43:02.268235","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/03a1749f-4df0-4837-bc70-b1de8aa663cc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/03a1749f-4df0-4837-bc70-b1de8aa663cc/pipeline.log\">pipeline</a>"]},{"id":"776d3d06-6299-46ed-b911-f07466766913","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1192.587381,"created":"2025-01-09T13:46:06.750644","updated":"2025-01-09T13:46:06.750655","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/776d3d06-6299-46ed-b911-f07466766913\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/776d3d06-6299-46ed-b911-f07466766913/pipeline.log\">pipeline</a>"]},{"id":"f3c88fdf-1b2e-4e80-ab53-feceef8875ae","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1256.570566,"created":"2025-01-09T13:54:19.454921","updated":"2025-01-09T13:54:19.454928","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f3c88fdf-1b2e-4e80-ab53-feceef8875ae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f3c88fdf-1b2e-4e80-ab53-feceef8875ae/pipeline.log\">pipeline</a>"]},{"id":"1eefc69e-a44c-4fbd-98a5-3c46d99d2ccf","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":862.324844,"created":"2025-01-09T13:43:03.477491","updated":"2025-01-09T13:43:03.477497","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1eefc69e-a44c-4fbd-98a5-3c46d99d2ccf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1eefc69e-a44c-4fbd-98a5-3c46d99d2ccf/pipeline.log\">pipeline</a>"]},{"id":"6237dd7c-1e46-4c2e-bd53-92f90b3be3ca","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5065.970132,"created":"2025-01-09T13:57:13.476202","updated":"2025-01-09T13:57:13.476209","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6237dd7c-1e46-4c2e-bd53-92f90b3be3ca\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6237dd7c-1e46-4c2e-bd53-92f90b3be3ca/pipeline.log\">pipeline</a>"]},{"id":"95799d40-0720-4a7e-aeb1-a12bff08bc89","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2065.625059,"created":"2025-01-09T13:57:03.225017","updated":"2025-01-09T13:57:03.225026","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/95799d40-0720-4a7e-aeb1-a12bff08bc89\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/95799d40-0720-4a7e-aeb1-a12bff08bc89/pipeline.log\">pipeline</a>"]},{"id":"7394d9ba-f811-49e7-a3e7-1e697aa25b64","name":"Fedora - s2i-python-container","runTime":3361.510887,"created":"2025-01-10T10:02:42.238756","updated":"2025-01-10T10:02:42.238765","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.dev.testing-farm.io/7394d9ba-f811-49e7-a3e7-1e697aa25b64\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7394d9ba-f811-49e7-a3e7-1e697aa25b64/pipeline.log\">pipeline</a>"]},{"id":"6ec5fef0-4d52-4e2b-a79e-9f82e4c11213","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1658.740495,"created":"2025-01-10T10:02:40.444266","updated":"2025-01-10T10:02:40.444279","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ec5fef0-4d52-4e2b-a79e-9f82e4c11213\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ec5fef0-4d52-4e2b-a79e-9f82e4c11213/pipeline.log\">pipeline</a>"]},{"id":"e7084787-f916-4b8a-85f9-a3b061df1219","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1626.649734,"created":"2025-01-10T10:02:46.426979","updated":"2025-01-10T10:02:46.426989","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7084787-f916-4b8a-85f9-a3b061df1219\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7084787-f916-4b8a-85f9-a3b061df1219/pipeline.log\">pipeline</a>"]},{"id":"c77b26d6-f0ef-4be9-9a4d-a4d8643a686b","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1632.949346,"created":"2025-01-10T10:02:40.483926","updated":"2025-01-10T10:02:40.483940","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c77b26d6-f0ef-4be9-9a4d-a4d8643a686b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c77b26d6-f0ef-4be9-9a4d-a4d8643a686b/pipeline.log\">pipeline</a>"]},{"id":"9fdd5d3a-b3c9-4b35-a9d0-36d6ce338cad","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2006.15215,"created":"2025-01-09T13:43:01.732508","updated":"2025-01-09T13:43:01.732517","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fdd5d3a-b3c9-4b35-a9d0-36d6ce338cad\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fdd5d3a-b3c9-4b35-a9d0-36d6ce338cad/pipeline.log\">pipeline</a>"]},{"id":"e7a7ece4-4576-462e-bdfb-c21528c676e2","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1696.985658,"created":"2025-01-10T10:02:39.790533","updated":"2025-01-10T10:02:39.790542","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7a7ece4-4576-462e-bdfb-c21528c676e2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7a7ece4-4576-462e-bdfb-c21528c676e2/pipeline.log\">pipeline</a>"]},{"id":"af48758e-cb12-4b85-a24b-a73030052685","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1646.132647,"created":"2025-01-10T10:02:40.597637","updated":"2025-01-10T10:02:40.597647","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af48758e-cb12-4b85-a24b-a73030052685\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af48758e-cb12-4b85-a24b-a73030052685/pipeline.log\">pipeline</a>"]},{"id":"36d53e95-e300-42d8-8cb3-8da30ea5e5eb","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2744.5763,"created":"2025-01-09T13:43:02.404229","updated":"2025-01-09T13:43:02.404237","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/36d53e95-e300-42d8-8cb3-8da30ea5e5eb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/36d53e95-e300-42d8-8cb3-8da30ea5e5eb/pipeline.log\">pipeline</a>"]},{"id":"6057003f-4fde-42e6-9d5f-acb52fddfd35","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":3782.43007,"created":"2025-01-09T14:00:17.177899","updated":"2025-01-09T14:00:17.177914","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6057003f-4fde-42e6-9d5f-acb52fddfd35\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6057003f-4fde-42e6-9d5f-acb52fddfd35/pipeline.log\">pipeline</a>"]},{"id":"d18685bf-5002-4f5a-ba6a-ccf7356c8a6d","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1557.505642,"created":"2025-01-09T13:43:01.698357","updated":"2025-01-09T13:43:01.698368","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d18685bf-5002-4f5a-ba6a-ccf7356c8a6d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d18685bf-5002-4f5a-ba6a-ccf7356c8a6d/pipeline.log\">pipeline</a>"]},{"id":"50d37889-796b-42b9-84c1-a1fab7de3822","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1206.832585,"created":"2025-01-09T13:43:10.783669","updated":"2025-01-09T13:43:10.783676","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/50d37889-796b-42b9-84c1-a1fab7de3822\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/50d37889-796b-42b9-84c1-a1fab7de3822/pipeline.log\">pipeline</a>"]},{"id":"60085468-2f33-4ecb-84c1-af14396aa7ec","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1663.583772,"created":"2025-01-09T13:56:42.114911","updated":"2025-01-09T13:56:42.114920","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/60085468-2f33-4ecb-84c1-af14396aa7ec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/60085468-2f33-4ecb-84c1-af14396aa7ec/pipeline.log\">pipeline</a>"]},{"id":"b22039f7-37cb-4e5c-822f-1a81db0dc42e","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2499.083862,"created":"2025-01-09T13:57:21.950352","updated":"2025-01-09T13:57:21.950358","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b22039f7-37cb-4e5c-822f-1a81db0dc42e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b22039f7-37cb-4e5c-822f-1a81db0dc42e/pipeline.log\">pipeline</a>"]},{"id":"ab0f89b2-38fd-406f-baf6-77fd3738983c","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":7160.487177,"created":"2025-01-09T14:04:08.042634","updated":"2025-01-09T14:04:08.042645","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab0f89b2-38fd-406f-baf6-77fd3738983c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab0f89b2-38fd-406f-baf6-77fd3738983c/pipeline.log\">pipeline</a>"]},{"id":"fc042453-f357-4633-b937-4ff4f132c898","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1343.676454,"created":"2025-01-09T13:43:02.489155","updated":"2025-01-09T13:43:02.489164","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc042453-f357-4633-b937-4ff4f132c898\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc042453-f357-4633-b937-4ff4f132c898/pipeline.log\">pipeline</a>"]},{"id":"bc569250-cee4-416f-bbba-fd3747d077b8","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":760.544699,"created":"2025-01-09T13:43:52.622991","updated":"2025-01-09T13:43:52.623001","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bc569250-cee4-416f-bbba-fd3747d077b8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bc569250-cee4-416f-bbba-fd3747d077b8/pipeline.log\">pipeline</a>"]},{"id":"153c9bcf-9c51-4b46-84b5-cfeb3bbddfda","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":776.394452,"created":"2025-01-09T13:43:02.061549","updated":"2025-01-09T13:43:02.061558","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/153c9bcf-9c51-4b46-84b5-cfeb3bbddfda\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/153c9bcf-9c51-4b46-84b5-cfeb3bbddfda/pipeline.log\">pipeline</a>"]},{"id":"0e6c5aeb-c220-48e5-bdd2-0b934377244e","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1395.630559,"created":"2025-01-09T13:43:04.250674","updated":"2025-01-09T13:43:04.250681","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0e6c5aeb-c220-48e5-bdd2-0b934377244e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0e6c5aeb-c220-48e5-bdd2-0b934377244e/pipeline.log\">pipeline</a>"]},{"id":"014c9110-0ef9-4eb1-8486-4fc5a0807f16","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2513.099396,"created":"2025-01-09T13:58:44.066411","updated":"2025-01-09T13:58:44.066420","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/014c9110-0ef9-4eb1-8486-4fc5a0807f16\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/014c9110-0ef9-4eb1-8486-4fc5a0807f16/pipeline.log\">pipeline</a>"]},{"id":"42450b26-942a-49e3-881b-5be72e5e3338","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1391.257734,"created":"2025-01-09T13:43:02.339755","updated":"2025-01-09T13:43:02.339762","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/42450b26-942a-49e3-881b-5be72e5e3338\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/42450b26-942a-49e3-881b-5be72e5e3338/pipeline.log\">pipeline</a>"]}]} -->