### PR TITLE
Remove deployement config

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -564,7 +564,6 @@ function ct_os_test_s2i_app_func() {
 
   local ip
   local check_command_exp
-  local image_id
 
   ip=$(ct_os_get_service_ip "${service_name}")
   # shellcheck disable=SC2001
@@ -707,7 +706,7 @@ function ct_os_test_template_app_func() {
 
   local ip
   local check_command_exp
-  local image_id
+
 
   ip=$(ct_os_get_service_ip "${service_name}")
   # shellcheck disable=SC2001
@@ -1178,23 +1177,4 @@ function ct_os_test_image_stream_quickstart() {
   return $result
 }
 
-# ct_os_service_image_info SERVICE_NAME
-# --------------------
-# Shows information about the image used by a specified service.
-# Argument: service_name - Service name (uesd for deployment config)
-function ct_os_service_image_info() {
-  local service_name=$1
-  local image_id
-  local namespace
-
-  # get image ID from the deployment config
-  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
-  namespace=${CT_NAMESPACE:-"$(oc project -q)"}
-
-  echo "  Information about the image we work with:"
-  oc get deploymentconfig.apps.openshift.io/"${service_name}" -o yaml | grep lastTriggeredImage
-  # for s2i builds, the resulting image is actually in the current namespace,
-  # so if the specified namespace does not succeed, try the current namespace
-  oc get isimage -n "${namespace}" "${image_id##*/}" -o yaml || oc get isimage "${image_id##*/}" -o yaml
-}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -566,12 +566,9 @@ function ct_os_test_s2i_app_func() {
   local check_command_exp
   local image_id
 
-  # get image ID from the deployment config
-  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
-
   ip=$(ct_os_get_service_ip "${service_name}")
   # shellcheck disable=SC2001
-  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g" -e "s|<SAME_IMAGE>|${image_id}|g")
+  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g")
 
   echo "  Checking APP using $check_command_exp ..."
   local result=0
@@ -712,12 +709,9 @@ function ct_os_test_template_app_func() {
   local check_command_exp
   local image_id
 
-  # get image ID from the deployment config
-  image_id=$(oc get "deploymentconfig.apps.openshift.io/${service_name}" -o custom-columns=IMAGE:.spec.template.spec.containers[*].image | tail -n 1)
-
   ip=$(ct_os_get_service_ip "${service_name}")
   # shellcheck disable=SC2001
-  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g" -e "s|<SAME_IMAGE>|${image_id}|g")
+  check_command_exp=$(echo "$check_command" | sed -e "s/<IP>/$ip/g")
 
   echo "  Checking APP using $check_command_exp ..."
   local result=0


### PR DESCRIPTION
This pull request deletes getting information about DeploymentConfigs.

The deploymentconfigs are deprecated since OpenShift 4.14+.

Information about image_id is not used in the project alone https://github.com/search?q=org%3Asclorg+%3CSAME_IMAGE%3E&type=code.
It is really safe do remove it.

Also function `ct_os_service_image_info` is not used in the whole https://github.com/sclorg organization
See https://github.com/search?q=org%3Asclorg+ct_os_service_image_info&type=code



<!-- issue-commentator = {"comment-id":"2876002285"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2875991784","data":[{"id":"e3754bef-9533-4677-b11d-b77853c8ed14","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":689.880536,"created":"2025-05-13T10:37:42.317207","updated":"2025-05-13T10:37:42.317213","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e3754bef-9533-4677-b11d-b77853c8ed14\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e3754bef-9533-4677-b11d-b77853c8ed14/pipeline.log\">pipeline</a>"]},{"id":"5b344156-a54c-4500-ac3e-0fada504a3ef","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":732.124528,"created":"2025-05-13T10:37:42.727229","updated":"2025-05-13T10:37:42.727236","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5b344156-a54c-4500-ac3e-0fada504a3ef\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5b344156-a54c-4500-ac3e-0fada504a3ef/pipeline.log\">pipeline</a>"]},{"id":"8659897d-2bdd-439d-855b-e6d5cb25a315","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":768.791123,"created":"2025-05-13T10:37:42.670720","updated":"2025-05-13T10:37:42.670727","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8659897d-2bdd-439d-855b-e6d5cb25a315\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8659897d-2bdd-439d-855b-e6d5cb25a315/pipeline.log\">pipeline</a>"]},{"id":"aee76e4c-2958-4c5f-a484-d6077e2b4ebc","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":854.258161,"created":"2025-05-13T10:37:41.594209","updated":"2025-05-13T10:37:41.594215","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aee76e4c-2958-4c5f-a484-d6077e2b4ebc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aee76e4c-2958-4c5f-a484-d6077e2b4ebc/pipeline.log\">pipeline</a>"]},{"id":"cd5334a1-2b28-4a71-b2b5-b10760dd5de1","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":951.22444,"created":"2025-05-13T10:37:41.553902","updated":"2025-05-13T10:37:41.553910","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cd5334a1-2b28-4a71-b2b5-b10760dd5de1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cd5334a1-2b28-4a71-b2b5-b10760dd5de1/pipeline.log\">pipeline</a>"]},{"id":"88c44d27-21b0-4b10-a0a5-3f0fc154ef29","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1149.357269,"created":"2025-05-13T10:37:40.909609","updated":"2025-05-13T10:37:40.909617","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c44d27-21b0-4b10-a0a5-3f0fc154ef29\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c44d27-21b0-4b10-a0a5-3f0fc154ef29/pipeline.log\">pipeline</a>"]},{"id":"8f236a8e-a441-4782-b36f-54fd5129652c","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1232.782957,"created":"2025-05-13T10:37:42.498894","updated":"2025-05-13T10:37:42.498901","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8f236a8e-a441-4782-b36f-54fd5129652c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8f236a8e-a441-4782-b36f-54fd5129652c/pipeline.log\">pipeline</a>"]},{"id":"87457dfc-cd11-4c7a-b0be-3f4ba6efef01","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1290.305276,"created":"2025-05-13T10:37:41.057016","updated":"2025-05-13T10:37:41.057024","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87457dfc-cd11-4c7a-b0be-3f4ba6efef01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87457dfc-cd11-4c7a-b0be-3f4ba6efef01/pipeline.log\">pipeline</a>"]},{"id":"6ac05c4d-204f-4a76-8d5f-507d840b8900","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1272.743849,"created":"2025-05-13T10:37:42.670058","updated":"2025-05-13T10:37:42.670063","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ac05c4d-204f-4a76-8d5f-507d840b8900\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ac05c4d-204f-4a76-8d5f-507d840b8900/pipeline.log\">pipeline</a>"]},{"id":"6efe0ab3-041c-4ab6-a81d-325cfc6acd69","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1354.187907,"created":"2025-05-13T10:38:22.178508","updated":"2025-05-13T10:38:22.178518","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6efe0ab3-041c-4ab6-a81d-325cfc6acd69\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6efe0ab3-041c-4ab6-a81d-325cfc6acd69/pipeline.log\">pipeline</a>"]},{"id":"c388617a-f386-43dc-a383-3c7404890ace","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1468.644111,"created":"2025-05-13T10:37:41.406632","updated":"2025-05-13T10:37:41.406638","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c388617a-f386-43dc-a383-3c7404890ace\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c388617a-f386-43dc-a383-3c7404890ace/pipeline.log\">pipeline</a>"]},{"id":"7df5a489-f54f-48a4-b630-74f46dfbdbb9","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1541.890729,"created":"2025-05-13T10:37:41.127818","updated":"2025-05-13T10:37:41.127826","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7df5a489-f54f-48a4-b630-74f46dfbdbb9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7df5a489-f54f-48a4-b630-74f46dfbdbb9/pipeline.log\">pipeline</a>"]},{"id":"d0e5d08b-2f00-45e3-96d2-350e3cb82ba9","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":723.727627,"created":"2025-05-13T10:52:44.021846","updated":"2025-05-13T10:52:44.021852","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d0e5d08b-2f00-45e3-96d2-350e3cb82ba9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d0e5d08b-2f00-45e3-96d2-350e3cb82ba9/pipeline.log\">pipeline</a>"]},{"id":"a495367f-cf93-4d9a-ad49-ec112672654e","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1645.972723,"created":"2025-05-13T10:37:41.472850","updated":"2025-05-13T10:37:41.472857","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a495367f-cf93-4d9a-ad49-ec112672654e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a495367f-cf93-4d9a-ad49-ec112672654e/pipeline.log\">pipeline</a>"]},{"id":"04cb870a-3fb2-4360-8569-ffdcf06b0569","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1666.514018,"created":"2025-05-13T10:37:43.571138","updated":"2025-05-13T10:37:43.571146","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04cb870a-3fb2-4360-8569-ffdcf06b0569\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04cb870a-3fb2-4360-8569-ffdcf06b0569/pipeline.log\">pipeline</a>"]},{"id":"6261c522-4c5b-4295-8ff3-348f6aaf53a3","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1716.706687,"created":"2025-05-13T10:37:42.644400","updated":"2025-05-13T10:37:42.644408","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6261c522-4c5b-4295-8ff3-348f6aaf53a3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6261c522-4c5b-4295-8ff3-348f6aaf53a3/pipeline.log\">pipeline</a>"]},{"id":"b3e0804f-fbac-44f1-b8f5-446878cb75cc","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2058.463822,"created":"2025-05-13T10:37:41.488103","updated":"2025-05-13T10:37:41.488220","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b3e0804f-fbac-44f1-b8f5-446878cb75cc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b3e0804f-fbac-44f1-b8f5-446878cb75cc/pipeline.log\">pipeline</a>"]},{"id":"d9b8c4eb-8813-4e5e-a147-7aaa10f81529","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1396.180767,"created":"2025-05-13T10:49:33.502078","updated":"2025-05-13T10:49:33.502084","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d9b8c4eb-8813-4e5e-a147-7aaa10f81529\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d9b8c4eb-8813-4e5e-a147-7aaa10f81529/pipeline.log\">pipeline</a>"]},{"id":"838a8e2a-7a18-4aba-9c44-476e17c068b4","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2119.208804,"created":"2025-05-13T10:37:39.835977","updated":"2025-05-13T10:37:39.835985","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/838a8e2a-7a18-4aba-9c44-476e17c068b4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/838a8e2a-7a18-4aba-9c44-476e17c068b4/pipeline.log\">pipeline</a>"]},{"id":"ad046172-86ec-4f69-820c-b752a79af151","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":802.180122,"created":"2025-05-13T10:59:48.207626","updated":"2025-05-13T10:59:48.207633","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ad046172-86ec-4f69-820c-b752a79af151\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ad046172-86ec-4f69-820c-b752a79af151/pipeline.log\">pipeline</a>"]},{"id":"48438751-f9b8-45d4-852d-6a524c27a0be","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2329.77731,"created":"2025-05-13T10:37:41.976061","updated":"2025-05-13T10:37:41.976068","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/48438751-f9b8-45d4-852d-6a524c27a0be\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/48438751-f9b8-45d4-852d-6a524c27a0be/pipeline.log\">pipeline</a>"]},{"id":"41d5f986-1d5e-405d-a556-ac5f6b9d8d4f","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1189.867311,"created":"2025-05-13T10:57:30.465722","updated":"2025-05-13T10:57:30.465729","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/41d5f986-1d5e-405d-a556-ac5f6b9d8d4f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/41d5f986-1d5e-405d-a556-ac5f6b9d8d4f/pipeline.log\">pipeline</a>"]},{"id":"03708ee6-4548-4810-8df8-667502dfc543","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1281.722596,"created":"2025-05-13T10:59:14.426394","updated":"2025-05-13T10:59:14.426405","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/03708ee6-4548-4810-8df8-667502dfc543\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/03708ee6-4548-4810-8df8-667502dfc543/pipeline.log\">pipeline</a>"]},{"id":"aef4b129-4f50-437d-b74e-febe038dc090","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2647.267297,"created":"2025-05-13T10:37:45.810262","updated":"2025-05-13T10:37:45.810269","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aef4b129-4f50-437d-b74e-febe038dc090\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aef4b129-4f50-437d-b74e-febe038dc090/pipeline.log\">pipeline</a>"]},{"id":"74419782-7b9a-4393-9340-a1f4a3b314e8","name":"RHEL8 - s2i-python-container","runTime":7180.384474,"created":"2025-05-13T12:51:20.842738","updated":"2025-05-13T12:51:20.842746","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74419782-7b9a-4393-9340-a1f4a3b314e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74419782-7b9a-4393-9340-a1f4a3b314e8/pipeline.log\">pipeline</a>"]},{"id":"1c082a6a-783d-4d00-ae07-6faeb8722412","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3121.829835,"created":"2025-05-13T10:37:40.949022","updated":"2025-05-13T10:37:40.949030","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c082a6a-783d-4d00-ae07-6faeb8722412\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c082a6a-783d-4d00-ae07-6faeb8722412/pipeline.log\">pipeline</a>"]},{"id":"8b388a37-08b9-486f-abe3-475353ad7918","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2605.032472,"created":"2025-05-13T10:50:39.544066","updated":"2025-05-13T10:50:39.544071","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b388a37-08b9-486f-abe3-475353ad7918\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b388a37-08b9-486f-abe3-475353ad7918/pipeline.log\">pipeline</a>"]},{"id":"8a80ef7a-45ce-4715-968f-2f6dc4784374","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2043.528718,"created":"2025-05-13T10:59:54.585751","updated":"2025-05-13T10:59:54.585757","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8a80ef7a-45ce-4715-968f-2f6dc4784374\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8a80ef7a-45ce-4715-968f-2f6dc4784374/pipeline.log\">pipeline</a>"]},{"id":"6c8454ef-5cc9-446a-a4f5-3c5232db9677","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4509.912635,"created":"2025-05-13T11:01:52.958318","updated":"2025-05-13T11:01:52.958325","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c8454ef-5cc9-446a-a4f5-3c5232db9677\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c8454ef-5cc9-446a-a4f5-3c5232db9677/pipeline.log\">pipeline</a>"]},{"id":"3a4f10d0-27b8-4822-9e7e-935cc2b58632","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4992.34074,"created":"2025-05-13T10:54:13.132231","updated":"2025-05-13T10:54:13.132240","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3a4f10d0-27b8-4822-9e7e-935cc2b58632\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3a4f10d0-27b8-4822-9e7e-935cc2b58632/pipeline.log\">pipeline</a>"]}]} -->