### PR TITLE
Remove usage `ct_os_service_image_info` that was removed by

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:
@@ -44,7 +47,7 @@ jobs:
         name: Parse manual input
         run: |
           # shellcheck disable=SC2086
-          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+          echo "result="[ ${{ github.event.issue.number }} ]"" >> $GITHUB_OUTPUT
         shell: bash
 
   validate-pr:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,5 @@ repos:
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports, --install-types, --non-interactive]
+        additional_dependencies:
+          - types-PyYAML

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-    language_version: python3.6
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v1.2.0
     hooks:
       - id: mypy
         args: [--strict, --ignore-missing-imports, --install-types, --non-interactive]

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -573,8 +573,6 @@ function ct_os_test_s2i_app_func() {
   local result=0
   eval "$check_command_exp" || result=1
 
-  ct_os_service_image_info "${service_name}"
-
   if [ $result -eq 0 ] ; then
     echo "  Check passed."
   else
@@ -715,8 +713,6 @@ function ct_os_test_template_app_func() {
   echo "  Checking APP using $check_command_exp ..."
   local result=0
   eval "$check_command_exp" || result=1
-
-  ct_os_service_image_info "${service_name}"
 
   if [ $result -eq 0 ] ; then
     echo "  Check passed."


### PR DESCRIPTION
This fixes regression caused by https://github.com/sclorg/container-common-scripts/pull/394

The function does not exist in whole this repository now.

<!-- issue-commentator = {"comment-id":"2915426510"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2915512630","data":[{"id":"3395030e-fdf7-4d77-a928-f532d6d35a21","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":716.961996,"created":"2025-05-28T08:41:58.811822","updated":"2025-05-28T08:41:58.811828","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3395030e-fdf7-4d77-a928-f532d6d35a21\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3395030e-fdf7-4d77-a928-f532d6d35a21/pipeline.log\">pipeline</a>"]},{"id":"d3543d43-12f2-46b9-9b84-d8d873c2b711","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":750.051691,"created":"2025-05-28T08:41:59.698928","updated":"2025-05-28T08:41:59.698934","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d3543d43-12f2-46b9-9b84-d8d873c2b711\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d3543d43-12f2-46b9-9b84-d8d873c2b711/pipeline.log\">pipeline</a>"]},{"id":"5164feba-e12e-4570-b6b7-aaadddb7a6e6","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":809.09187,"created":"2025-05-28T08:41:59.052735","updated":"2025-05-28T08:41:59.052747","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5164feba-e12e-4570-b6b7-aaadddb7a6e6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5164feba-e12e-4570-b6b7-aaadddb7a6e6/pipeline.log\">pipeline</a>"]},{"id":"29d13e4b-a3f2-47df-a85b-06657d356ab7","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":882.966693,"created":"2025-05-28T08:41:58.526411","updated":"2025-05-28T08:41:58.526417","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/29d13e4b-a3f2-47df-a85b-06657d356ab7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/29d13e4b-a3f2-47df-a85b-06657d356ab7/pipeline.log\">pipeline</a>"]},{"id":"8eee0fc9-0a50-47ed-a6a3-37b1582ef20e","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1398.235453,"created":"2025-05-28T08:41:58.402286","updated":"2025-05-28T08:41:58.402291","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8eee0fc9-0a50-47ed-a6a3-37b1582ef20e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8eee0fc9-0a50-47ed-a6a3-37b1582ef20e/pipeline.log\">pipeline</a>"]},{"id":"d6c74ee8-0344-4c1f-abd4-e0d8ff6d13cc","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1925.951809,"created":"2025-05-28T08:41:57.694281","updated":"2025-05-28T08:41:57.694293","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d6c74ee8-0344-4c1f-abd4-e0d8ff6d13cc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d6c74ee8-0344-4c1f-abd4-e0d8ff6d13cc/pipeline.log\">pipeline</a>"]},{"id":"65f244e6-c7c9-4858-968b-c080e6586eb4","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1190.545606,"created":"2025-05-28T08:54:26.068677","updated":"2025-05-28T08:54:26.068686","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/65f244e6-c7c9-4858-968b-c080e6586eb4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/65f244e6-c7c9-4858-968b-c080e6586eb4/pipeline.log\">pipeline</a>"]},{"id":"5134cb1e-8f68-4d1b-9717-a5767395d939","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":2010.740301,"created":"2025-05-28T08:41:58.856318","updated":"2025-05-28T08:41:58.856324","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5134cb1e-8f68-4d1b-9717-a5767395d939\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5134cb1e-8f68-4d1b-9717-a5767395d939/pipeline.log\">pipeline</a>"]},{"id":"6b6dc992-dac0-44a7-850b-2157ac7361fc","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":2136.447419,"created":"2025-05-28T08:41:59.004482","updated":"2025-05-28T08:41:59.004488","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6b6dc992-dac0-44a7-850b-2157ac7361fc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6b6dc992-dac0-44a7-850b-2157ac7361fc/pipeline.log\">pipeline</a>"]},{"id":"f5de2759-fccc-4df5-b0aa-1b03ef6bc1b9","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1148.963885,"created":"2025-05-28T08:59:02.371432","updated":"2025-05-28T08:59:02.371439","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f5de2759-fccc-4df5-b0aa-1b03ef6bc1b9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f5de2759-fccc-4df5-b0aa-1b03ef6bc1b9/pipeline.log\">pipeline</a>"]},{"id":"a1da2e44-fc41-4e26-b6b7-a5e1623eed97","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2370.824249,"created":"2025-05-28T08:41:58.075682","updated":"2025-05-28T08:41:58.075689","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1da2e44-fc41-4e26-b6b7-a5e1623eed97\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1da2e44-fc41-4e26-b6b7-a5e1623eed97/pipeline.log\">pipeline</a>"]},{"id":"2231719c-6627-4f8f-8bd1-3a9a772f5da9","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":2464.486528,"created":"2025-05-28T08:41:57.597716","updated":"2025-05-28T08:41:57.597725","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2231719c-6627-4f8f-8bd1-3a9a772f5da9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2231719c-6627-4f8f-8bd1-3a9a772f5da9/pipeline.log\">pipeline</a>"]},{"id":"dd61e3fd-e471-4b04-90ae-7a6ebd376af4","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2721.628628,"created":"2025-05-28T08:41:59.114991","updated":"2025-05-28T08:41:59.114996","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd61e3fd-e471-4b04-90ae-7a6ebd376af4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd61e3fd-e471-4b04-90ae-7a6ebd376af4/pipeline.log\">pipeline</a>"]},{"id":"5fee7c8d-a92a-439b-a9f5-92ee6406780e","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":749.959265,"created":"2025-05-28T09:19:33.138709","updated":"2025-05-28T09:19:33.138715","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5fee7c8d-a92a-439b-a9f5-92ee6406780e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5fee7c8d-a92a-439b-a9f5-92ee6406780e/pipeline.log\">pipeline</a>"]},{"id":"24916192-8e14-4ca8-a82f-e4a5621d653a","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2338.324688,"created":"2025-05-28T08:55:13.630715","updated":"2025-05-28T08:55:13.630720","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/24916192-8e14-4ca8-a82f-e4a5621d653a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/24916192-8e14-4ca8-a82f-e4a5621d653a/pipeline.log\">pipeline</a>"]},{"id":"84078930-b4cf-4495-9ddb-ca4b9f19bfae","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":3164.940614,"created":"2025-05-28T08:41:57.210587","updated":"2025-05-28T08:41:57.210598","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/84078930-b4cf-4495-9ddb-ca4b9f19bfae\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/84078930-b4cf-4495-9ddb-ca4b9f19bfae/pipeline.log\">pipeline</a>"]},{"id":"5f086e56-247a-4f5b-9b70-6b0a509fb24c","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1665.622286,"created":"2025-05-28T09:07:09.475227","updated":"2025-05-28T09:07:09.475238","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f086e56-247a-4f5b-9b70-6b0a509fb24c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f086e56-247a-4f5b-9b70-6b0a509fb24c/pipeline.log\">pipeline</a>"]},{"id":"65ce0f90-e76e-4614-ad7d-0c3de20f445c","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":3464.96761,"created":"2025-05-28T08:41:57.710278","updated":"2025-05-28T08:41:57.710287","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/65ce0f90-e76e-4614-ad7d-0c3de20f445c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/65ce0f90-e76e-4614-ad7d-0c3de20f445c/pipeline.log\">pipeline</a>"]},{"id":"dc7f41b0-0147-420a-93f3-2a0566a1d0f5","name":"RHEL9 - s2i-perl-container","runTime":2401.047711,"created":"2025-05-28T11:29:18.333833","updated":"2025-05-28T11:29:18.333840","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc7f41b0-0147-420a-93f3-2a0566a1d0f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc7f41b0-0147-420a-93f3-2a0566a1d0f5/pipeline.log\">pipeline</a>"]},{"id":"4da0267c-3f6b-48fb-ac02-907e29da07de","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":568.270171,"created":"2025-05-28T09:32:24.421031","updated":"2025-05-28T09:32:24.421036","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4da0267c-3f6b-48fb-ac02-907e29da07de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4da0267c-3f6b-48fb-ac02-907e29da07de/pipeline.log\">pipeline</a>"]},{"id":"9a84b128-854e-475b-b06c-e7a08aec654e","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1038.859008,"created":"2025-05-28T09:27:43.557799","updated":"2025-05-28T09:27:43.557807","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9a84b128-854e-475b-b06c-e7a08aec654e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9a84b128-854e-475b-b06c-e7a08aec654e/pipeline.log\">pipeline</a>"]},{"id":"5056de73-b8b0-440e-a61a-49aa1861f792","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":613.610336,"created":"2025-05-28T09:35:47.348252","updated":"2025-05-28T09:35:47.348259","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5056de73-b8b0-440e-a61a-49aa1861f792\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5056de73-b8b0-440e-a61a-49aa1861f792/pipeline.log\">pipeline</a>"]},{"id":"286ce582-74a3-417b-b981-b788f03503b1","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3036.391686,"created":"2025-05-28T08:56:09.580816","updated":"2025-05-28T08:56:09.580822","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/286ce582-74a3-417b-b981-b788f03503b1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/286ce582-74a3-417b-b981-b788f03503b1/pipeline.log\">pipeline</a>"]},{"id":"04a4eb70-906f-4cc3-8a63-bcc29133a42f","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1954.801036,"created":"2025-05-28T09:15:21.077789","updated":"2025-05-28T09:15:21.077799","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04a4eb70-906f-4cc3-8a63-bcc29133a42f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04a4eb70-906f-4cc3-8a63-bcc29133a42f/pipeline.log\">pipeline</a>"]},{"id":"3895bc51-9f48-4ccb-9cc9-15b2b9526ede","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2319.780552,"created":"2025-05-28T11:27:47.656398","updated":"2025-05-28T11:27:47.656423","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3895bc51-9f48-4ccb-9cc9-15b2b9526ede\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3895bc51-9f48-4ccb-9cc9-15b2b9526ede/pipeline.log\">pipeline</a>"]},{"id":"ed1fd73c-3b1d-4912-9f7f-41e041edf6af","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1840.331007,"created":"2025-05-28T09:19:28.499482","updated":"2025-05-28T09:19:28.499489","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed1fd73c-3b1d-4912-9f7f-41e041edf6af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed1fd73c-3b1d-4912-9f7f-41e041edf6af/pipeline.log\">pipeline</a>"]},{"id":"5bf1d30c-9f65-4b6a-a8c2-9d4a35e9a495","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":2193.272626,"created":"2025-05-28T09:24:28.029394","updated":"2025-05-28T09:24:28.029400","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bf1d30c-9f65-4b6a-a8c2-9d4a35e9a495\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bf1d30c-9f65-4b6a-a8c2-9d4a35e9a495/pipeline.log\">pipeline</a>"]},{"id":"1961f5ed-f220-4049-b91d-e6c4f4a5333d","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4804.436068,"created":"2025-05-28T08:42:31.332789","updated":"2025-05-28T08:42:31.332795","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1961f5ed-f220-4049-b91d-e6c4f4a5333d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1961f5ed-f220-4049-b91d-e6c4f4a5333d/pipeline.log\">pipeline</a>"]},{"id":"3c8181e8-39a3-49f6-96f5-48237334e394","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5351.875965,"created":"2025-05-28T08:42:08.264647","updated":"2025-05-28T08:42:08.264654","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c8181e8-39a3-49f6-96f5-48237334e394\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c8181e8-39a3-49f6-96f5-48237334e394/pipeline.log\">pipeline</a>"]},{"id":"d7d13c9c-79db-4028-8def-d1b5bc5bb55c","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":7437.081401,"created":"2025-05-28T09:16:21.044448","updated":"2025-05-28T09:16:21.044455","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7d13c9c-79db-4028-8def-d1b5bc5bb55c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7d13c9c-79db-4028-8def-d1b5bc5bb55c/pipeline.log\">pipeline</a>"]}]} -->