### PR TITLE
Add support for sending failed logs to logdetective

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,7 @@ failed_version() {
 }
 
 analyze_logs_by_logdetective() {
+  # logdetective should not break the test functionality
   set +e
   local log_file_name="$1"
   echo "Sending failed log by fpaste command to paste bin."
@@ -39,16 +40,26 @@ analyze_logs_by_logdetective() {
   raw_paste_bin_link="${paste_bin_link//view/view\/raw}"
   echo "Sending log file to logdetective server: ${raw_paste_bin_link}"
   echo "-------- LOGDETECTIVE TEST LOG ANALYSIS START --------"
+  logdetective_test_file=$(mktemp "/tmp/logdetective_test.XXXXXX")
   # shellcheck disable=SC2181
-  if ! curl -k --insecure --header "Content-Type: application/json" --request POST --data "{\"url\":\"${raw_paste_bin_link}\"}" "$LOGDETECTIVE_SERVER/analyze" > /tmp/logdetective_test_output.txt; then
+  if ! curl -k --insecure --header "Content-Type: application/json" --request POST --data "{\"url\":\"${raw_paste_bin_link}\"}" "$LOGDETECTIVE_SERVER/analyze" >> "${logdetective_test_file}"; then
     echo "ERROR: Failed to analyze log file by logdetective server."
-    cat "/tmp/logdetective_test_output.txt"
+    cat "${logdetective_test_file}"
     echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FAILED --------"
     set -e
     return
   fi
-  jq -rC '.explanation.text' < "/tmp/logdetective_test_output.txt"
   set -e
+  jq -rC '.explanation.text' < "${logdetective_test_file}"
+  # This part of code is from https://github.com/teemtee/tmt/blob/main/tmt/steps/scripts/tmt-file-submit
+  if [ -z "$TMT_TEST_PIDFILE" ]; then
+    echo "File submit to data dir can be used only in the context of a running test."
+    return
+  fi
+  # This variable is set by tmt
+  [ -d "$TMT_TEST_DATA" ] || mkdir -p "$TMT_TEST_DATA"
+  cp -f "${logdetective_test_file}" "$TMT_TEST_DATA"
+  echo "File '${logdetective_test_file}' stored to '$TMT_TEST_DATA'."
   echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FINISHED --------"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,7 @@ failed_version() {
 }
 
 analyze_logs_by_logdetective() {
+  set +e
   local log_file_name="$1"
   echo "Sending failed log by fpaste command to paste bin."
   paste_bin_link=$(fpaste "$log_file_name")
@@ -43,6 +44,7 @@ analyze_logs_by_logdetective() {
     echo "ERROR: Failed to analyze log file by logdetective server."
     cat "/tmp/logdetective_test_output.txt"
     echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FAILED --------"
+    set -e
     return
   fi
   jq -rC '.explanation.text' < "/tmp/logdetective_test_output.txt"
@@ -75,7 +77,9 @@ for dir in ${VERSIONS}; do
     tmp_file=$(mktemp "/tmp/${IMAGE_NAME}-${OS}-${dir}.XXXXXX")
     VERSION=$dir test/run 2>&1 | tee "$tmp_file"
     ret_code=$?
-    analyze_logs_by_logdetective "$tmp_file"
+    if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+      analyze_logs_by_logdetective "$tmp_file"
+    fi
     failed_version "$ret_code" "$dir"
     rm -f "$tmp_file"
   fi

--- a/test.sh
+++ b/test.sh
@@ -48,6 +48,7 @@ analyze_logs_by_logdetective() {
     return
   fi
   jq -rC '.explanation.text' < "/tmp/logdetective_test_output.txt"
+  set -e
   echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FINISHED --------"
 }
 
@@ -74,9 +75,12 @@ for dir in ${VERSIONS}; do
   fi
 
   if [ -n "${TEST_MODE}" ]; then
-    tmp_file=$(mktemp "/tmp/${IMAGE_NAME}-${OS}-${dir}.XXXXXX")
+    set -o pipefail
+    tmp_file=$(mktemp "/tmp/${OS}-${dir}.XXXXXX")
     VERSION=$dir test/run 2>&1 | tee "$tmp_file"
     ret_code=$?
+    set +o pipefail
+    cat "${tmp_file}"
     if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
       analyze_logs_by_logdetective "$tmp_file"
     fi


### PR DESCRIPTION
Add support for sending failed logs to logdetective

New function called 'analyze_logs_by_logdetective()' is used as for 'build' part as for 'test' part.

Each function is marked by 'LOGDETECTIVE {BUILD|TEST} tag so we can easily find them.

Also parsing logs have been enhanced no parse_output is needed. Let's call it directly.
It is used on Fedora. We use podman for building
and there is no needed to use complicated functions.

<!-- issue-commentator = {"comment-id":"2976807025"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2996919023","data":[{"id":"4d236908-7fbe-45db-9b93-65770daf7eb4","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1118.177398,"created":"2025-07-21T07:59:36.834915","updated":"2025-07-21T07:59:36.834921","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d236908-7fbe-45db-9b93-65770daf7eb4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d236908-7fbe-45db-9b93-65770daf7eb4/pipeline.log\">pipeline</a>"]},{"id":"80a33d59-e524-4c6d-8e2d-6ce4a10935a1","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2538.325092,"created":"2025-07-21T07:59:37.543575","updated":"2025-07-21T07:59:37.543581","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/80a33d59-e524-4c6d-8e2d-6ce4a10935a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/80a33d59-e524-4c6d-8e2d-6ce4a10935a1/pipeline.log\">pipeline</a>"]},{"id":"667dcb1f-c646-4d17-8826-98345660c576","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1655.187181,"created":"2025-07-21T07:59:36.387870","updated":"2025-07-21T07:59:36.387881","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/667dcb1f-c646-4d17-8826-98345660c576\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/667dcb1f-c646-4d17-8826-98345660c576/pipeline.log\">pipeline</a>"]},{"id":"17ed2c5c-c557-4947-a61a-d572debb800b","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1710.043768,"created":"2025-07-21T07:59:38.385450","updated":"2025-07-21T07:59:38.385457","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/17ed2c5c-c557-4947-a61a-d572debb800b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/17ed2c5c-c557-4947-a61a-d572debb800b/pipeline.log\">pipeline</a>"]},{"id":"06971793-1764-45c5-a34a-8c4f06654a09","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1146.722445,"created":"2025-07-21T08:32:03.984831","updated":"2025-07-21T08:32:03.984837","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/06971793-1764-45c5-a34a-8c4f06654a09\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/06971793-1764-45c5-a34a-8c4f06654a09/pipeline.log\">pipeline</a>"]},{"id":"e3ead91a-8f1f-4eb3-94bc-3b778b45c5bd","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":6362.595861,"created":"2025-07-21T07:59:38.142518","updated":"2025-07-21T07:59:38.142527","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e3ead91a-8f1f-4eb3-94bc-3b778b45c5bd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e3ead91a-8f1f-4eb3-94bc-3b778b45c5bd/pipeline.log\">pipeline</a>"]},{"id":"7608befd-91b6-46c1-9d7b-f56706addfe9","name":"RHEL9 - postgresql-container","runTime":2119.434384,"created":"2025-07-22T06:27:31.346101","updated":"2025-07-22T06:27:31.346106","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7608befd-91b6-46c1-9d7b-f56706addfe9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7608befd-91b6-46c1-9d7b-f56706addfe9/pipeline.log\">pipeline</a>"]},{"id":"88608b74-bfef-47f3-98e7-8c4cb0f71165","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1702.776524,"created":"2025-07-21T07:59:36.701813","updated":"2025-07-21T07:59:36.701820","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/88608b74-bfef-47f3-98e7-8c4cb0f71165\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/88608b74-bfef-47f3-98e7-8c4cb0f71165/pipeline.log\">pipeline</a>"]},{"id":"b0eaf901-c3f1-4028-bee3-37134e8b75a9","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1170.982136,"created":"2025-07-22T06:27:31.633088","updated":"2025-07-22T06:27:31.633095","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b0eaf901-c3f1-4028-bee3-37134e8b75a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b0eaf901-c3f1-4028-bee3-37134e8b75a9/pipeline.log\">pipeline</a>"]},{"id":"39452fdd-497d-4bc2-82e6-e5dc8df9423b","name":"Fedora - postgresql-container","status":"error","outcome":"unknown","runTime":1987.481196,"created":"2025-07-22T06:27:33.725837","updated":"2025-07-22T06:27:33.725842","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/39452fdd-497d-4bc2-82e6-e5dc8df9423b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/39452fdd-497d-4bc2-82e6-e5dc8df9423b/pipeline.log\">pipeline</a>"]},{"id":"87aa2201-477e-4cc4-bbf5-5a21d0433497","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":17346.320228,"created":"2025-07-21T07:59:38.224253","updated":"2025-07-21T07:59:38.224261","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/87aa2201-477e-4cc4-bbf5-5a21d0433497\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/87aa2201-477e-4cc4-bbf5-5a21d0433497/pipeline.log\">pipeline</a>"]},{"id":"85c5f2fe-50a6-4696-ba5d-a8954b5958c3","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":16793.611693,"created":"2025-07-21T07:59:36.878001","updated":"2025-07-21T07:59:36.878007","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/85c5f2fe-50a6-4696-ba5d-a8954b5958c3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/85c5f2fe-50a6-4696-ba5d-a8954b5958c3/pipeline.log\">pipeline</a>"]},{"id":"79ca668f-a177-4c3b-90ec-b740b8bbb4df","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":19662.735478,"created":"2025-07-21T07:59:43.339963","updated":"2025-07-21T07:59:43.339970","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/79ca668f-a177-4c3b-90ec-b740b8bbb4df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/79ca668f-a177-4c3b-90ec-b740b8bbb4df/pipeline.log\">pipeline</a>"]},{"id":"d59608b9-fdfc-4913-924a-6b88adf2570b","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":14647.341946,"created":"2025-07-21T07:59:38.057472","updated":"2025-07-21T07:59:38.057479","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d59608b9-fdfc-4913-924a-6b88adf2570b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d59608b9-fdfc-4913-924a-6b88adf2570b/pipeline.log\">pipeline</a>"]},{"id":"8046792b-77cb-46d9-bb9a-ede60425fc38","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1127.409862,"created":"2025-07-22T06:27:33.000437","updated":"2025-07-22T06:27:33.000444","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8046792b-77cb-46d9-bb9a-ede60425fc38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8046792b-77cb-46d9-bb9a-ede60425fc38/pipeline.log\">pipeline</a>"]},{"id":"ee303480-1508-4022-bf42-9608561b9f09","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":14465.672246,"created":"2025-07-21T08:42:02.863351","updated":"2025-07-21T08:42:02.863358","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ee303480-1508-4022-bf42-9608561b9f09\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ee303480-1508-4022-bf42-9608561b9f09/pipeline.log\">pipeline</a>"]},{"id":"cb35db0e-c20b-4f50-bb87-60552bf8b103","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":16928.875601,"created":"2025-07-21T07:59:46.528766","updated":"2025-07-21T07:59:46.528774","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cb35db0e-c20b-4f50-bb87-60552bf8b103\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cb35db0e-c20b-4f50-bb87-60552bf8b103/pipeline.log\">pipeline</a>"]},{"id":"5c4acc91-78ee-4924-88c4-70238618e844","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":17043.800988,"created":"2025-07-21T07:59:36.192887","updated":"2025-07-21T07:59:36.192896","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5c4acc91-78ee-4924-88c4-70238618e844\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5c4acc91-78ee-4924-88c4-70238618e844/pipeline.log\">pipeline</a>"]},{"id":"e5c3b798-acf9-4081-b810-eb1e07dc7e3d","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":12985.984878,"created":"2025-07-21T07:59:37.118351","updated":"2025-07-21T07:59:37.118361","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e5c3b798-acf9-4081-b810-eb1e07dc7e3d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e5c3b798-acf9-4081-b810-eb1e07dc7e3d/pipeline.log\">pipeline</a>"]},{"id":"1958b862-ccec-4760-943e-a098532ae030","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":10436.006909,"created":"2025-07-21T08:36:14.880574","updated":"2025-07-21T08:36:14.880585","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1958b862-ccec-4760-943e-a098532ae030\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1958b862-ccec-4760-943e-a098532ae030/pipeline.log\">pipeline</a>"]},{"id":"ca1c4e9d-f4c1-4ffd-a257-2b4acb687a65","name":"CentOS Stream 9 - s2i-python-container","status":"error","outcome":"unknown","runTime":1985.641327,"created":"2025-07-22T06:27:31.290350","updated":"2025-07-22T06:27:31.290361","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ca1c4e9d-f4c1-4ffd-a257-2b4acb687a65\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ca1c4e9d-f4c1-4ffd-a257-2b4acb687a65/pipeline.log\">pipeline</a>"]},{"id":"c1cfbcbb-5faa-41b9-8dfc-08239b06b67a","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":13406.456279,"created":"2025-07-21T07:59:36.747613","updated":"2025-07-21T07:59:36.747638","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c1cfbcbb-5faa-41b9-8dfc-08239b06b67a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c1cfbcbb-5faa-41b9-8dfc-08239b06b67a/pipeline.log\">pipeline</a>"]},{"id":"d67ab1a6-e94f-4e65-9d8a-0fd2f4a8ea95","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1258.154143,"created":"2025-07-21T07:59:38.432399","updated":"2025-07-21T07:59:38.432407","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d67ab1a6-e94f-4e65-9d8a-0fd2f4a8ea95\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d67ab1a6-e94f-4e65-9d8a-0fd2f4a8ea95/pipeline.log\">pipeline</a>"]},{"id":"428cc401-79a7-4a0d-b7bf-94b8eb3071c1","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1410.937249,"created":"2025-07-21T08:27:58.088801","updated":"2025-07-21T08:27:58.088811","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/428cc401-79a7-4a0d-b7bf-94b8eb3071c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/428cc401-79a7-4a0d-b7bf-94b8eb3071c1/pipeline.log\">pipeline</a>"]},{"id":"955082df-b50f-45dd-9a2a-68b3c945ea9b","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1366.230672,"created":"2025-07-21T08:30:12.153575","updated":"2025-07-21T08:30:12.153582","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/955082df-b50f-45dd-9a2a-68b3c945ea9b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/955082df-b50f-45dd-9a2a-68b3c945ea9b/pipeline.log\">pipeline</a>"]},{"id":"3f54c6b1-a5bc-4ff3-9a24-ca792dc35c79","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4624.52332,"created":"2025-07-21T07:59:36.937753","updated":"2025-07-21T07:59:36.937760","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f54c6b1-a5bc-4ff3-9a24-ca792dc35c79\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f54c6b1-a5bc-4ff3-9a24-ca792dc35c79/pipeline.log\">pipeline</a>"]},{"id":"7ab226d2-5152-491c-84f8-2fab46b823df","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1858.996704,"created":"2025-07-21T07:59:36.549153","updated":"2025-07-21T07:59:36.549160","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ab226d2-5152-491c-84f8-2fab46b823df\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ab226d2-5152-491c-84f8-2fab46b823df/pipeline.log\">pipeline</a>"]},{"id":"9149f447-a8cb-4f79-a7a4-4819ea2c31e5","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2441.911687,"created":"2025-07-21T07:59:36.743286","updated":"2025-07-21T07:59:36.743295","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9149f447-a8cb-4f79-a7a4-4819ea2c31e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9149f447-a8cb-4f79-a7a4-4819ea2c31e5/pipeline.log\">pipeline</a>"]},{"id":"7e50c402-1bb0-4b8c-856e-4ad1aa924d45","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":568.793163,"created":"2025-07-22T06:27:31.327931","updated":"2025-07-22T06:27:31.327938","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e50c402-1bb0-4b8c-856e-4ad1aa924d45\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e50c402-1bb0-4b8c-856e-4ad1aa924d45/pipeline.log\">pipeline</a>"]},{"id":"6d382079-c0b3-47d6-a127-46507ba87e09","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1432.322342,"created":"2025-07-21T08:00:29.273478","updated":"2025-07-21T08:00:29.273486","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d382079-c0b3-47d6-a127-46507ba87e09\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d382079-c0b3-47d6-a127-46507ba87e09/pipeline.log\">pipeline</a>"]}]} -->