### PR TITLE
Try to push image to OpenShift internal registry more times

### DIFF
--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -461,9 +461,15 @@ function ct_os_upload_image() {
     return 1
   fi
   output_name="$OCP4_REGISTER/$namespace/$image_name"
-
-  docker tag "${source_name}" "${output_name}"
-  docker push "${output_name}"
+  COUNTER=0
+  while [ $COUNTER -lt 3 ]; do
+    docker tag "${source_name}" "${output_name}"
+    if docker push "${output_name}" -eq 0; then
+      return 0
+    fi
+    COUNTER=$((COUNTER+1))
+  done
+  return 1
 }
 
 # ct_os_is_tag_exists IS_NAME TAG


### PR DESCRIPTION
Try to push image to OpenShift internal registry more times

The error in case push failed.

This fixes error like:

```
Copying blob sha256:415d74f354df4c83b246f01be89785ea693ee130c55b856b2d4d868103e8582e
Error: trying to reuse blob sha256:44212c8bb03bfcbaa3e281221507f684d16690b8d059ac051d6a21652a596210 at destination: checking whether a blob sha256:44212c8bb03bfcbaa3e281221507f684d16690b8d059ac051d6a21652a596210 exists in default-route-openshift-image-registry.apps.ocp4-apps-stacks.hosted.psi.rdu2.redhat.com/sclorg-test-31062/python-312: received unexpected HTTP status: 500 Internal Server Error
warning: Cannot check if git requires authentication.
```

<!-- issue-commentator = {"comment-id":"3103045475"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3103121287","data":[{"id":"a4c43f57-e030-4455-8cb8-7e35b6642dbb","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":697.659937,"created":"2025-07-22T14:34:43.650741","updated":"2025-07-22T14:34:43.650749","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a4c43f57-e030-4455-8cb8-7e35b6642dbb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a4c43f57-e030-4455-8cb8-7e35b6642dbb/pipeline.log\">pipeline</a>"]},{"id":"3fa8423c-93e2-4355-beef-9fa96e131559","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":632.51666,"created":"2025-07-22T14:34:44.273817","updated":"2025-07-22T14:34:44.273824","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3fa8423c-93e2-4355-beef-9fa96e131559\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3fa8423c-93e2-4355-beef-9fa96e131559/pipeline.log\">pipeline</a>"]},{"id":"a16ea910-5926-48ae-ab9c-55e13c115016","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":855.77883,"created":"2025-07-22T14:34:45.960730","updated":"2025-07-22T14:34:45.960738","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a16ea910-5926-48ae-ab9c-55e13c115016\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a16ea910-5926-48ae-ab9c-55e13c115016/pipeline.log\">pipeline</a>"]},{"id":"fb7e30bf-1290-415d-8940-39568f70ce3f","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":777.167567,"created":"2025-07-22T14:37:40.961246","updated":"2025-07-22T14:37:40.961254","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fb7e30bf-1290-415d-8940-39568f70ce3f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fb7e30bf-1290-415d-8940-39568f70ce3f/pipeline.log\">pipeline</a>"]},{"id":"9ee4a519-683f-4a05-8f77-54c081d62195","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1183.910417,"created":"2025-07-22T14:34:43.465512","updated":"2025-07-22T14:34:43.465520","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9ee4a519-683f-4a05-8f77-54c081d62195\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9ee4a519-683f-4a05-8f77-54c081d62195/pipeline.log\">pipeline</a>"]},{"id":"fd264b13-29f9-48ad-90d7-c6c4262c8282","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1110.278839,"created":"2025-07-22T14:34:44.654581","updated":"2025-07-22T14:34:44.654590","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd264b13-29f9-48ad-90d7-c6c4262c8282\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd264b13-29f9-48ad-90d7-c6c4262c8282/pipeline.log\">pipeline</a>"]},{"id":"78d29013-7247-4c26-adae-5bca1994721d","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1319.227065,"created":"2025-07-22T14:34:45.563798","updated":"2025-07-22T14:34:45.563804","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/78d29013-7247-4c26-adae-5bca1994721d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/78d29013-7247-4c26-adae-5bca1994721d/pipeline.log\">pipeline</a>"]},{"id":"d43baf59-eebd-46ef-b772-cbb447156307","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1233.909208,"created":"2025-07-22T14:34:43.676603","updated":"2025-07-22T14:34:43.676610","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d43baf59-eebd-46ef-b772-cbb447156307\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d43baf59-eebd-46ef-b772-cbb447156307/pipeline.log\">pipeline</a>"]},{"id":"7e810eba-6aeb-4c1b-a49e-52d15fabdaa9","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":566.609567,"created":"2025-07-22T14:57:05.187500","updated":"2025-07-22T14:57:05.187507","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e810eba-6aeb-4c1b-a49e-52d15fabdaa9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e810eba-6aeb-4c1b-a49e-52d15fabdaa9/pipeline.log\">pipeline</a>"]},{"id":"5770c244-9716-47e1-b0ab-41452f97f5f6","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":656.617697,"created":"2025-07-22T14:57:17.806652","updated":"2025-07-22T14:57:17.806659","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5770c244-9716-47e1-b0ab-41452f97f5f6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5770c244-9716-47e1-b0ab-41452f97f5f6/pipeline.log\">pipeline</a>"]},{"id":"a000605a-c070-4238-ad94-ddf6fc35e038","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":2342.916612,"created":"2025-07-22T14:34:44.845307","updated":"2025-07-22T14:34:44.845315","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a000605a-c070-4238-ad94-ddf6fc35e038\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a000605a-c070-4238-ad94-ddf6fc35e038/pipeline.log\">pipeline</a>"]},{"id":"ae8a0087-9217-4265-b202-2db72ca89066","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":2469.294894,"created":"2025-07-22T14:34:46.604736","updated":"2025-07-22T14:34:46.604743","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae8a0087-9217-4265-b202-2db72ca89066\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae8a0087-9217-4265-b202-2db72ca89066/pipeline.log\">pipeline</a>"]},{"id":"42a08435-9a54-4584-8e6e-4e48c8dded1f","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2445.921579,"created":"2025-07-22T14:34:45.908637","updated":"2025-07-22T14:34:45.908645","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/42a08435-9a54-4584-8e6e-4e48c8dded1f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/42a08435-9a54-4584-8e6e-4e48c8dded1f/pipeline.log\">pipeline</a>"]},{"id":"828ee3d5-6073-4c5b-a360-bce95e28ace7","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":2649.533212,"created":"2025-07-22T14:34:44.047561","updated":"2025-07-22T14:34:44.047569","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/828ee3d5-6073-4c5b-a360-bce95e28ace7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/828ee3d5-6073-4c5b-a360-bce95e28ace7/pipeline.log\">pipeline</a>"]},{"id":"7455cd03-f431-43c5-b451-b612bc76d68e","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":2791.775564,"created":"2025-07-22T14:34:45.669289","updated":"2025-07-22T14:34:45.669299","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7455cd03-f431-43c5-b451-b612bc76d68e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7455cd03-f431-43c5-b451-b612bc76d68e/pipeline.log\">pipeline</a>"]},{"id":"11bfccb6-779d-4a0e-a219-300c6d435d9a","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":824.857423,"created":"2025-07-22T15:08:52.849336","updated":"2025-07-22T15:08:52.849344","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/11bfccb6-779d-4a0e-a219-300c6d435d9a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/11bfccb6-779d-4a0e-a219-300c6d435d9a/pipeline.log\">pipeline</a>"]},{"id":"689ebb7b-81f0-48a5-bb13-7ed019629a57","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":2356.614939,"created":"2025-07-22T14:47:07.369837","updated":"2025-07-22T14:47:07.369843","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/689ebb7b-81f0-48a5-bb13-7ed019629a57\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/689ebb7b-81f0-48a5-bb13-7ed019629a57/pipeline.log\">pipeline</a>"]},{"id":"3a9e4c89-876f-45bd-a9ce-ca497a7468e3","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3214.358954,"created":"2025-07-22T14:34:43.152697","updated":"2025-07-22T14:34:43.152705","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3a9e4c89-876f-45bd-a9ce-ca497a7468e3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3a9e4c89-876f-45bd-a9ce-ca497a7468e3/pipeline.log\">pipeline</a>"]},{"id":"0fcd4c41-8665-4774-9d31-f08d27ffb1d4","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1936.456135,"created":"2025-07-22T14:55:07.584534","updated":"2025-07-22T14:55:07.584542","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0fcd4c41-8665-4774-9d31-f08d27ffb1d4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0fcd4c41-8665-4774-9d31-f08d27ffb1d4/pipeline.log\">pipeline</a>"]},{"id":"7f552e12-766d-4b02-8a07-76e22980da14","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":3384.202353,"created":"2025-07-22T14:34:45.830605","updated":"2025-07-22T14:34:45.830615","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f552e12-766d-4b02-8a07-76e22980da14\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f552e12-766d-4b02-8a07-76e22980da14/pipeline.log\">pipeline</a>"]},{"id":"49347340-0f3c-4d72-bc80-d2fb856f700e","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2923.369882,"created":"2025-07-22T14:47:01.370000","updated":"2025-07-22T14:47:01.370015","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/49347340-0f3c-4d72-bc80-d2fb856f700e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/49347340-0f3c-4d72-bc80-d2fb856f700e/pipeline.log\">pipeline</a>"]},{"id":"c3814937-e438-4255-bd7b-340c1e990e92","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":3804.523753,"created":"2025-07-22T14:34:46.127666","updated":"2025-07-22T14:34:46.127673","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3814937-e438-4255-bd7b-340c1e990e92\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3814937-e438-4255-bd7b-340c1e990e92/pipeline.log\">pipeline</a>"]},{"id":"d3df6172-9db7-43bf-a436-b1df97661851","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":3827.504827,"created":"2025-07-22T14:34:52.606332","updated":"2025-07-22T14:34:52.606337","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d3df6172-9db7-43bf-a436-b1df97661851\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d3df6172-9db7-43bf-a436-b1df97661851/pipeline.log\">pipeline</a>"]},{"id":"960b7d44-675d-43fa-a240-0bbf4cbf8646","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2990.067264,"created":"2025-07-22T14:51:04.729873","updated":"2025-07-22T14:51:04.729881","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/960b7d44-675d-43fa-a240-0bbf4cbf8646\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/960b7d44-675d-43fa-a240-0bbf4cbf8646/pipeline.log\">pipeline</a>"]},{"id":"c027be28-471e-4b14-a21a-94919a1a77a9","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":2970.013776,"created":"2025-07-22T14:52:09.027375","updated":"2025-07-22T14:52:09.027382","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c027be28-471e-4b14-a21a-94919a1a77a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c027be28-471e-4b14-a21a-94919a1a77a9/pipeline.log\">pipeline</a>"]},{"id":"d28c79fa-e9e2-48de-819f-f5f4ad9d48b7","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"error","runTime":3001.868928,"created":"2025-07-22T14:57:01.925523","updated":"2025-07-22T14:57:01.925531","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d28c79fa-e9e2-48de-819f-f5f4ad9d48b7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d28c79fa-e9e2-48de-819f-f5f4ad9d48b7/pipeline.log\">pipeline</a>"]},{"id":"4ded85c1-fa95-4ba3-9249-b9daf0c097d4","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":2538.182202,"created":"2025-07-22T15:09:37.140704","updated":"2025-07-22T15:09:37.140713","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ded85c1-fa95-4ba3-9249-b9daf0c097d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ded85c1-fa95-4ba3-9249-b9daf0c097d4/pipeline.log\">pipeline</a>"]},{"id":"444664de-ca4d-4188-ba12-6a9f187f6086","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5146.087989,"created":"2025-07-22T14:34:43.502745","updated":"2025-07-22T14:34:43.502752","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/444664de-ca4d-4188-ba12-6a9f187f6086\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/444664de-ca4d-4188-ba12-6a9f187f6086/pipeline.log\">pipeline</a>"]},{"id":"74083690-4541-4038-abfe-e51916d23a55","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5890.493221,"created":"2025-07-22T14:53:15.324267","updated":"2025-07-22T14:53:15.324272","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74083690-4541-4038-abfe-e51916d23a55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74083690-4541-4038-abfe-e51916d23a55/pipeline.log\">pipeline</a>"]},{"id":"56685b6f-b523-44ca-ba88-ffd0f83a0e6b","name":"RHEL8 - s2i-python-container","runTime":8130.31617,"created":"2025-07-22T14:55:08.101029","updated":"2025-07-22T14:55:08.101043","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/56685b6f-b523-44ca-ba88-ffd0f83a0e6b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/56685b6f-b523-44ca-ba88-ffd0f83a0e6b/pipeline.log\">pipeline</a>"]}]} -->