### PR TITLE
Enable running container tests

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -111,6 +111,11 @@ test-openshift-pytest: script_env += TEST_OPENSHIFT_PYTEST=true
 test-openshift-pytest: tag
 	VERSIONS="$(VERSIONS)" BASE_IMAGE_NAME="$(BASE_IMAGE_NAME)" $(script_env) $(test)
 
+.PHONY: test-pytest
+test-pytest: script_env += TEST_PYTEST=true
+test-pytest: tag
+	VERSIONS="$(VERSIONS)" BASE_IMAGE_NAME="$(BASE_IMAGE_NAME)" $(script_env) $(test)
+
 
 .PHONY: shellcheck
 shellcheck:


### PR DESCRIPTION
The script which runs the PyTest is `test/run-pytest`

<!-- issue-commentator = {"comment-id":"3224938990"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3224991774","data":[{"id":"1ac39fd1-f8c3-4822-b69c-8ae029a02025","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":717.489051,"created":"2025-08-26T16:42:09.334190","updated":"2025-08-26T16:42:09.334198","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1ac39fd1-f8c3-4822-b69c-8ae029a02025\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1ac39fd1-f8c3-4822-b69c-8ae029a02025/pipeline.log\">pipeline</a>"]},{"id":"1f81e446-9ff7-4590-8cba-548f48186e22","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":775.961033,"created":"2025-08-26T16:42:07.188567","updated":"2025-08-26T16:42:07.188574","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1f81e446-9ff7-4590-8cba-548f48186e22\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1f81e446-9ff7-4590-8cba-548f48186e22/pipeline.log\">pipeline</a>"]},{"id":"19f07c91-5f44-4979-ae81-cc38f05a1b55","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":793.860463,"created":"2025-08-26T16:42:08.851619","updated":"2025-08-26T16:42:08.851626","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/19f07c91-5f44-4979-ae81-cc38f05a1b55\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/19f07c91-5f44-4979-ae81-cc38f05a1b55/pipeline.log\">pipeline</a>"]},{"id":"adf5e7a1-777c-4390-a6c2-9fed111edc17","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":746.137831,"created":"2025-08-26T16:42:09.211982","updated":"2025-08-26T16:42:09.211988","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/adf5e7a1-777c-4390-a6c2-9fed111edc17\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/adf5e7a1-777c-4390-a6c2-9fed111edc17/pipeline.log\">pipeline</a>"]},{"id":"a39c1815-4aa1-428f-9c0c-62a02ac4b948","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":805.490756,"created":"2025-08-26T16:42:07.847100","updated":"2025-08-26T16:42:07.847105","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a39c1815-4aa1-428f-9c0c-62a02ac4b948\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a39c1815-4aa1-428f-9c0c-62a02ac4b948/pipeline.log\">pipeline</a>"]},{"id":"da6c100f-76da-4ec5-80de-a7c423f14d08","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":749.555463,"created":"2025-08-26T16:42:09.551915","updated":"2025-08-26T16:42:09.551925","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/da6c100f-76da-4ec5-80de-a7c423f14d08\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/da6c100f-76da-4ec5-80de-a7c423f14d08/pipeline.log\">pipeline</a>"]},{"id":"879f7492-b05d-43a8-be01-82b4cc006c2d","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1156.837514,"created":"2025-08-26T16:42:07.443726","updated":"2025-08-26T16:42:07.443735","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/879f7492-b05d-43a8-be01-82b4cc006c2d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/879f7492-b05d-43a8-be01-82b4cc006c2d/pipeline.log\">pipeline</a>"]},{"id":"4bee0e5b-7b31-4d99-ace4-d91a12adc96f","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1182.51239,"created":"2025-08-26T16:42:20.248037","updated":"2025-08-26T16:42:20.248045","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4bee0e5b-7b31-4d99-ace4-d91a12adc96f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4bee0e5b-7b31-4d99-ace4-d91a12adc96f/pipeline.log\">pipeline</a>"]},{"id":"8fbbbce8-5bd0-405f-843a-85bdc932839d","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1417.791564,"created":"2025-08-26T16:42:09.030756","updated":"2025-08-26T16:42:09.030764","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8fbbbce8-5bd0-405f-843a-85bdc932839d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8fbbbce8-5bd0-405f-843a-85bdc932839d/pipeline.log\">pipeline</a>"]},{"id":"9c3a5f76-5dc4-4970-9fc9-260548146783","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1868.732705,"created":"2025-08-26T16:42:09.154213","updated":"2025-08-26T16:42:09.154220","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c3a5f76-5dc4-4970-9fc9-260548146783\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c3a5f76-5dc4-4970-9fc9-260548146783/pipeline.log\">pipeline</a>"]},{"id":"4c47a56c-3975-40d1-9e76-47011fc06042","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1972.54126,"created":"2025-08-26T16:42:13.755661","updated":"2025-08-26T16:42:13.755669","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4c47a56c-3975-40d1-9e76-47011fc06042\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4c47a56c-3975-40d1-9e76-47011fc06042/pipeline.log\">pipeline</a>"]},{"id":"a774c7dc-4b14-4230-9029-b64dca128593","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1201.344882,"created":"2025-08-26T16:56:32.053962","updated":"2025-08-26T16:56:32.053970","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a774c7dc-4b14-4230-9029-b64dca128593\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a774c7dc-4b14-4230-9029-b64dca128593/pipeline.log\">pipeline</a>"]},{"id":"232b6e15-3fd9-4689-b685-3c60cc950da8","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1298.651011,"created":"2025-08-26T16:55:07.322511","updated":"2025-08-26T16:55:07.322518","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/232b6e15-3fd9-4689-b685-3c60cc950da8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/232b6e15-3fd9-4689-b685-3c60cc950da8/pipeline.log\">pipeline</a>"]},{"id":"678ac6ab-5af3-4c88-a341-6b1c649b7767","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2127.038934,"created":"2025-08-26T16:42:07.173542","updated":"2025-08-26T16:42:07.173548","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/678ac6ab-5af3-4c88-a341-6b1c649b7767\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/678ac6ab-5af3-4c88-a341-6b1c649b7767/pipeline.log\">pipeline</a>"]},{"id":"59c30a28-b622-4c3a-9e66-a740ef9d0911","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1337.67767,"created":"2025-08-26T16:56:33.977640","updated":"2025-08-26T16:56:33.977646","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59c30a28-b622-4c3a-9e66-a740ef9d0911\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59c30a28-b622-4c3a-9e66-a740ef9d0911/pipeline.log\">pipeline</a>"]},{"id":"e9fda556-690e-4e1a-a758-48d084aaa8c3","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2589.391459,"created":"2025-08-26T16:42:08.250547","updated":"2025-08-26T16:42:08.250555","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9fda556-690e-4e1a-a758-48d084aaa8c3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9fda556-690e-4e1a-a758-48d084aaa8c3/pipeline.log\">pipeline</a>"]},{"id":"d0106008-f140-4ab0-a818-1164f75675ed","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":2557.224829,"created":"2025-08-26T16:42:09.298258","updated":"2025-08-26T16:42:09.298264","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0106008-f140-4ab0-a818-1164f75675ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0106008-f140-4ab0-a818-1164f75675ed/pipeline.log\">pipeline</a>"]},{"id":"126af512-485a-4a57-9e98-30b4f99a3eb2","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1702.903907,"created":"2025-08-26T16:56:33.270927","updated":"2025-08-26T16:56:33.270935","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/126af512-485a-4a57-9e98-30b4f99a3eb2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/126af512-485a-4a57-9e98-30b4f99a3eb2/pipeline.log\">pipeline</a>"]},{"id":"f8de109e-2439-4979-b65d-814a48487a32","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1767.420542,"created":"2025-08-26T16:56:41.240893","updated":"2025-08-26T16:56:41.240898","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8de109e-2439-4979-b65d-814a48487a32\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8de109e-2439-4979-b65d-814a48487a32/pipeline.log\">pipeline</a>"]},{"id":"6eca4e2b-9fc6-4bfe-8988-6134e1a4ebe8","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":2753.70534,"created":"2025-08-26T16:42:43.927588","updated":"2025-08-26T16:42:43.927594","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6eca4e2b-9fc6-4bfe-8988-6134e1a4ebe8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6eca4e2b-9fc6-4bfe-8988-6134e1a4ebe8/pipeline.log\">pipeline</a>"]},{"id":"23181ff1-8fad-435a-9b9d-4cf10fb71f8f","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"error","runTime":1062.512046,"created":"2025-08-26T17:14:36.116404","updated":"2025-08-26T17:14:36.116413","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/23181ff1-8fad-435a-9b9d-4cf10fb71f8f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/23181ff1-8fad-435a-9b9d-4cf10fb71f8f/pipeline.log\">pipeline</a>"]},{"id":"846d0de0-20a1-4ddb-a4b8-a7a9a4e64238","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":946.457094,"created":"2025-08-26T17:16:42.779559","updated":"2025-08-26T17:16:42.779566","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/846d0de0-20a1-4ddb-a4b8-a7a9a4e64238\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/846d0de0-20a1-4ddb-a4b8-a7a9a4e64238/pipeline.log\">pipeline</a>"]},{"id":"88201776-124d-4b4d-b781-0e74d0a011c3","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3126.74979,"created":"2025-08-26T16:42:07.759362","updated":"2025-08-26T16:42:07.759369","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/88201776-124d-4b4d-b781-0e74d0a011c3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/88201776-124d-4b4d-b781-0e74d0a011c3/pipeline.log\">pipeline</a>"]},{"id":"d0539039-e1a4-410e-8d16-9b239b17eec9","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":3185.755364,"created":"2025-08-26T16:42:09.071991","updated":"2025-08-26T16:42:09.071998","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0539039-e1a4-410e-8d16-9b239b17eec9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0539039-e1a4-410e-8d16-9b239b17eec9/pipeline.log\">pipeline</a>"]},{"id":"34c96d77-c8a4-4d79-988a-fa5a29a0faa8","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2628.383516,"created":"2025-08-26T17:06:33.289197","updated":"2025-08-26T17:06:33.289203","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/34c96d77-c8a4-4d79-988a-fa5a29a0faa8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/34c96d77-c8a4-4d79-988a-fa5a29a0faa8/pipeline.log\">pipeline</a>"]},{"id":"c3b779c4-cdee-4196-9fdc-8bdedfa78703","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"error","runTime":4527.137036,"created":"2025-08-26T16:42:07.426689","updated":"2025-08-26T16:42:07.426696","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3b779c4-cdee-4196-9fdc-8bdedfa78703\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3b779c4-cdee-4196-9fdc-8bdedfa78703/pipeline.log\">pipeline</a>"]},{"id":"921c600a-76dc-4efb-b618-ed16f7fafdbd","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5094.06057,"created":"2025-08-26T17:02:41.865217","updated":"2025-08-26T17:02:41.865224","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/921c600a-76dc-4efb-b618-ed16f7fafdbd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/921c600a-76dc-4efb-b618-ed16f7fafdbd/pipeline.log\">pipeline</a>"]},{"id":"c5b53a26-84b5-46df-b4e6-246a90526d65","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":6253.297996,"created":"2025-08-26T16:56:33.207511","updated":"2025-08-26T16:56:33.207518","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5b53a26-84b5-46df-b4e6-246a90526d65\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5b53a26-84b5-46df-b4e6-246a90526d65/pipeline.log\">pipeline</a>"]},{"id":"46113a3e-2552-4704-a3f6-4c7498343c59","name":"RHEL8 - s2i-python-container","runTime":6504.932074,"created":"2025-08-26T17:02:30.467455","updated":"2025-08-26T17:02:30.467462","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46113a3e-2552-4704-a3f6-4c7498343c59\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46113a3e-2552-4704-a3f6-4c7498343c59/pipeline.log\">pipeline</a>"]}]} -->