### PR TITLE
Return code variable is not 'result' but 'ret_code'

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -92,7 +92,7 @@ for dir in ${VERSIONS}; do
     ret_code=$?
     set +o pipefail
     cat "${tmp_file}"
-    if [[ "$result" != "0" ]]; then
+    if [[ "$ret_code" != "0" ]]; then
       if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
         analyze_logs_by_logdetective "$tmp_file"
       fi
@@ -125,7 +125,7 @@ for dir in ${VERSIONS}; do
       ret_code=$?
       set +o pipefail
       cat "${tmp_file}"
-      if [[ "$result" != "0" ]]; then
+      if [[ "$ret_code" != "0" ]]; then
         if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
           analyze_logs_by_logdetective "$tmp_file"
         fi


### PR DESCRIPTION
Otherwise logdetective is called everytime

<!-- issue-commentator = {"comment-id":"3242577892"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3242674573","data":[{"id":"6be34f06-a60c-408f-a452-19a33beade5b","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1389.410821,"created":"2025-09-01T14:38:02.363185","updated":"2025-09-01T14:38:02.363194","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be34f06-a60c-408f-a452-19a33beade5b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be34f06-a60c-408f-a452-19a33beade5b/pipeline.log\">pipeline</a>"]},{"id":"80becc6f-b6cf-491e-8492-b9d46a1a2fae","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":2668.16929,"created":"2025-09-01T14:20:31.769569","updated":"2025-09-01T14:20:31.769578","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/80becc6f-b6cf-491e-8492-b9d46a1a2fae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/80becc6f-b6cf-491e-8492-b9d46a1a2fae/pipeline.log\">pipeline</a>"]},{"id":"622c8573-8188-4691-b16e-7b0d8891ae81","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1039.768606,"created":"2025-09-01T14:57:05.639717","updated":"2025-09-01T14:57:05.639723","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/622c8573-8188-4691-b16e-7b0d8891ae81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/622c8573-8188-4691-b16e-7b0d8891ae81/pipeline.log\">pipeline</a>"]},{"id":"9a072a63-ceef-4230-b47e-d9a8e06e36c5","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2936.747737,"created":"2025-09-01T14:27:47.476071","updated":"2025-09-01T14:27:47.476078","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9a072a63-ceef-4230-b47e-d9a8e06e36c5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9a072a63-ceef-4230-b47e-d9a8e06e36c5/pipeline.log\">pipeline</a>"]},{"id":"f23fc1b1-a948-49c5-acbd-427f7aca0cf9","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":1991.59852,"created":"2025-09-01T14:57:17.951193","updated":"2025-09-01T14:57:17.951201","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f23fc1b1-a948-49c5-acbd-427f7aca0cf9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f23fc1b1-a948-49c5-acbd-427f7aca0cf9/pipeline.log\">pipeline</a>"]},{"id":"a3d5365c-1b68-400f-b477-41f3355eaf04","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":2407.306866,"created":"2025-09-01T14:57:24.139008","updated":"2025-09-01T14:57:24.139016","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a3d5365c-1b68-400f-b477-41f3355eaf04\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a3d5365c-1b68-400f-b477-41f3355eaf04/pipeline.log\">pipeline</a>"]},{"id":"7f4bed6c-f610-4176-a614-39a5493a6d99","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2441.577564,"created":"2025-09-01T14:57:29.374035","updated":"2025-09-01T14:57:29.374043","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7f4bed6c-f610-4176-a614-39a5493a6d99\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7f4bed6c-f610-4176-a614-39a5493a6d99/pipeline.log\">pipeline</a>"]},{"id":"d4aced31-62e6-4a51-b452-b3d76565047d","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":698.590411,"created":"2025-09-01T15:31:08.163208","updated":"2025-09-01T15:31:08.163215","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d4aced31-62e6-4a51-b452-b3d76565047d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d4aced31-62e6-4a51-b452-b3d76565047d/pipeline.log\">pipeline</a>"]},{"id":"8def97b1-3cef-4f18-8d58-cfc32190fc8d","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1567.40852,"created":"2025-09-01T15:15:16.152697","updated":"2025-09-01T15:15:16.152706","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8def97b1-3cef-4f18-8d58-cfc32190fc8d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8def97b1-3cef-4f18-8d58-cfc32190fc8d/pipeline.log\">pipeline</a>"]},{"id":"4e034c51-5319-4a3a-b15f-ac1927e24f9a","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2636.444374,"created":"2025-09-01T15:01:30.791922","updated":"2025-09-01T15:01:30.791932","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e034c51-5319-4a3a-b15f-ac1927e24f9a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e034c51-5319-4a3a-b15f-ac1927e24f9a/pipeline.log\">pipeline</a>"]},{"id":"4217fc90-8d64-4a76-b570-5a5cb243d505","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":756.937697,"created":"2025-09-01T15:33:57.208816","updated":"2025-09-01T15:33:57.208822","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4217fc90-8d64-4a76-b570-5a5cb243d505\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4217fc90-8d64-4a76-b570-5a5cb243d505/pipeline.log\">pipeline</a>"]},{"id":"fecedcd9-5f12-4796-ae67-1e0498b8d58f","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1678.938806,"created":"2025-09-01T15:21:32.902818","updated":"2025-09-01T15:21:32.902826","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fecedcd9-5f12-4796-ae67-1e0498b8d58f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fecedcd9-5f12-4796-ae67-1e0498b8d58f/pipeline.log\">pipeline</a>"]},{"id":"1383c94b-6181-4f83-9751-1a27db48e4d6","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":729.899714,"created":"2025-09-01T15:37:43.081826","updated":"2025-09-01T15:37:43.081832","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1383c94b-6181-4f83-9751-1a27db48e4d6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1383c94b-6181-4f83-9751-1a27db48e4d6/pipeline.log\">pipeline</a>"]},{"id":"24bba29f-5897-4a31-821c-35114b33e736","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1387.049802,"created":"2025-09-01T15:29:13.724525","updated":"2025-09-01T15:29:13.724532","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/24bba29f-5897-4a31-821c-35114b33e736\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/24bba29f-5897-4a31-821c-35114b33e736/pipeline.log\">pipeline</a>"]},{"id":"8bb76f6d-eb90-4095-a4a6-9c2c9cdabd02","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":801.854331,"created":"2025-09-01T15:39:42.925220","updated":"2025-09-01T15:39:42.925230","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8bb76f6d-eb90-4095-a4a6-9c2c9cdabd02\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8bb76f6d-eb90-4095-a4a6-9c2c9cdabd02/pipeline.log\">pipeline</a>"]},{"id":"321498fa-1c55-4fcd-9efc-a816a47a087c","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1919.698668,"created":"2025-09-01T15:31:33.445431","updated":"2025-09-01T15:31:33.445437","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/321498fa-1c55-4fcd-9efc-a816a47a087c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/321498fa-1c55-4fcd-9efc-a816a47a087c/pipeline.log\">pipeline</a>"]},{"id":"8c2a5d03-f703-418a-a0da-d7856195034b","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1233.088088,"created":"2025-09-01T15:44:00.113226","updated":"2025-09-01T15:44:00.113236","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c2a5d03-f703-418a-a0da-d7856195034b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c2a5d03-f703-418a-a0da-d7856195034b/pipeline.log\">pipeline</a>"]},{"id":"eebf9528-9a24-4be5-9bb8-aaaa032fc0ac","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1821.819112,"created":"2025-09-01T15:34:07.243875","updated":"2025-09-01T15:34:07.243882","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eebf9528-9a24-4be5-9bb8-aaaa032fc0ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eebf9528-9a24-4be5-9bb8-aaaa032fc0ac/pipeline.log\">pipeline</a>"]},{"id":"56254eb9-c9dc-4c20-b0fd-c8c75974336c","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1058.956759,"created":"2025-09-01T15:52:07.152030","updated":"2025-09-01T15:52:07.152039","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/56254eb9-c9dc-4c20-b0fd-c8c75974336c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/56254eb9-c9dc-4c20-b0fd-c8c75974336c/pipeline.log\">pipeline</a>"]},{"id":"77b2d6f1-f444-4a1d-b96f-ee2c384dd809","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1215.676254,"created":"2025-09-01T15:48:18.288402","updated":"2025-09-01T15:48:18.288408","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/77b2d6f1-f444-4a1d-b96f-ee2c384dd809\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/77b2d6f1-f444-4a1d-b96f-ee2c384dd809/pipeline.log\">pipeline</a>"]},{"id":"1ea16120-f4d5-4a9d-bed4-8f61b3bf21c0","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1593.50047,"created":"2025-09-01T15:46:05.710601","updated":"2025-09-01T15:46:05.710608","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ea16120-f4d5-4a9d-bed4-8f61b3bf21c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ea16120-f4d5-4a9d-bed4-8f61b3bf21c0/pipeline.log\">pipeline</a>"]},{"id":"722c4dcb-a319-4e65-9673-18fe6c77211a","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1832.187167,"created":"2025-09-01T15:44:02.468894","updated":"2025-09-01T15:44:02.468900","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/722c4dcb-a319-4e65-9673-18fe6c77211a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/722c4dcb-a319-4e65-9673-18fe6c77211a/pipeline.log\">pipeline</a>"]},{"id":"ed5b2054-0de2-4796-a954-8f244e551940","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1406.927887,"created":"2025-09-01T15:54:03.428364","updated":"2025-09-01T15:54:03.428370","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed5b2054-0de2-4796-a954-8f244e551940\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed5b2054-0de2-4796-a954-8f244e551940/pipeline.log\">pipeline</a>"]},{"id":"8cc91cc6-1eb1-48d2-a115-89c347b1fa1f","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2100.104684,"created":"2025-09-01T15:43:57.964284","updated":"2025-09-01T15:43:57.964292","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cc91cc6-1eb1-48d2-a115-89c347b1fa1f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cc91cc6-1eb1-48d2-a115-89c347b1fa1f/pipeline.log\">pipeline</a>"]},{"id":"7adbc10f-50a8-4371-9db1-f0f7ffb9b7a9","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2239.399588,"created":"2025-09-01T15:53:31.456027","updated":"2025-09-01T15:53:31.456037","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7adbc10f-50a8-4371-9db1-f0f7ffb9b7a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7adbc10f-50a8-4371-9db1-f0f7ffb9b7a9/pipeline.log\">pipeline</a>"]},{"id":"d3049ee0-207f-4bc5-adf4-4ed97e222974","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":2960.221811,"created":"2025-09-01T15:43:34.064001","updated":"2025-09-01T15:43:34.064010","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d3049ee0-207f-4bc5-adf4-4ed97e222974\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d3049ee0-207f-4bc5-adf4-4ed97e222974/pipeline.log\">pipeline</a>"]},{"id":"a0df73bc-a237-4fa1-9fdd-043f72d8f2fb","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":6263.378937,"created":"2025-09-01T15:18:39.492617","updated":"2025-09-01T15:18:39.492626","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0df73bc-a237-4fa1-9fdd-043f72d8f2fb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0df73bc-a237-4fa1-9fdd-043f72d8f2fb/pipeline.log\">pipeline</a>"]},{"id":"8808932a-50f6-4be6-9d39-b5f97e82740e","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4496.451011,"created":"2025-09-01T15:53:45.261141","updated":"2025-09-01T15:53:45.261153","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8808932a-50f6-4be6-9d39-b5f97e82740e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8808932a-50f6-4be6-9d39-b5f97e82740e/pipeline.log\">pipeline</a>"]},{"id":"376ec691-f5f5-423c-b890-cef096203e02","name":"CentOS Stream 9 - s2i-python-container","runTime":4714.57519,"created":"2025-09-01T15:51:07.273906","updated":"2025-09-01T15:51:07.273913","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/376ec691-f5f5-423c-b890-cef096203e02\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/376ec691-f5f5-423c-b890-cef096203e02/pipeline.log\">pipeline</a>"]}]} -->