### PR TITLE
Let's switch back again to `set -e`.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,7 @@ failed_version() {
 
 analyze_logs_by_logdetective() {
   # logdetective should not break the test functionality
+  # Therefore `set +e` is setup
   set +e
   local log_file_name="$1"
   echo "Sending failed log by fpaste command to paste bin."
@@ -46,14 +47,16 @@ analyze_logs_by_logdetective() {
     echo "ERROR: Failed to analyze log file by logdetective server."
     cat "${logdetective_test_file}"
     echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FAILED --------"
+    # Let's switch it back
     set -e
     return
   fi
-  set -e
   jq -rC '.explanation.text' < "${logdetective_test_file}"
   # This part of code is from https://github.com/teemtee/tmt/blob/main/tmt/steps/scripts/tmt-file-submit
   if [ -z "$TMT_TEST_PIDFILE" ]; then
     echo "File submit to data dir can be used only in the context of a running test."
+    # Let's switch it back
+    set -e
     return
   fi
   # This variable is set by tmt
@@ -61,6 +64,8 @@ analyze_logs_by_logdetective() {
   cp -f "${logdetective_test_file}" "$TMT_TEST_DATA"
   echo "File '${logdetective_test_file}' stored to '$TMT_TEST_DATA'."
   echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FINISHED --------"
+  # Let's switch it back
+  set -e
 }
 
 # This adds backwards compatibility if only single version needs to be testing


### PR DESCRIPTION
<!-- issue-commentator = {"comment-id":"3245632274"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3245691022","data":[{"id":"20c1d3b6-47a9-4eec-a42e-f46e75c4e717","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":669.659736,"created":"2025-09-02T14:40:12.894459","updated":"2025-09-02T14:40:12.894468","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/20c1d3b6-47a9-4eec-a42e-f46e75c4e717\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/20c1d3b6-47a9-4eec-a42e-f46e75c4e717/pipeline.log\">pipeline</a>"]},{"id":"58c1fd11-1688-4ba6-9dec-6f21c07e636d","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1039.555242,"created":"2025-09-02T14:37:10.194184","updated":"2025-09-02T14:37:10.194192","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/58c1fd11-1688-4ba6-9dec-6f21c07e636d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/58c1fd11-1688-4ba6-9dec-6f21c07e636d/pipeline.log\">pipeline</a>"]},{"id":"88c4d26f-f82b-4ffb-b54a-3069787ad4ab","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1652.311819,"created":"2025-09-02T15:13:15.338219","updated":"2025-09-02T15:13:15.338226","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c4d26f-f82b-4ffb-b54a-3069787ad4ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/88c4d26f-f82b-4ffb-b54a-3069787ad4ab/pipeline.log\">pipeline</a>"]},{"id":"1ef9cab1-9568-4348-8d39-d9bf0e8befc9","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2079.262165,"created":"2025-09-02T15:07:37.351198","updated":"2025-09-02T15:07:37.351205","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ef9cab1-9568-4348-8d39-d9bf0e8befc9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ef9cab1-9568-4348-8d39-d9bf0e8befc9/pipeline.log\">pipeline</a>"]},{"id":"4b0f6cf1-33f2-4351-96fd-353f062a54de","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":2281.935772,"created":"2025-09-02T15:10:48.676565","updated":"2025-09-02T15:10:48.676571","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b0f6cf1-33f2-4351-96fd-353f062a54de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b0f6cf1-33f2-4351-96fd-353f062a54de/pipeline.log\">pipeline</a>"]},{"id":"1c58a32f-53d7-4bde-a3d7-d3293125d889","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":2976.95035,"created":"2025-09-02T15:09:29.455830","updated":"2025-09-02T15:09:29.455836","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c58a32f-53d7-4bde-a3d7-d3293125d889\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c58a32f-53d7-4bde-a3d7-d3293125d889/pipeline.log\">pipeline</a>"]},{"id":"85931731-157c-46e6-a0eb-f5f35c74251d","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":2508.747001,"created":"2025-09-02T15:18:00.600949","updated":"2025-09-02T15:18:00.600954","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/85931731-157c-46e6-a0eb-f5f35c74251d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/85931731-157c-46e6-a0eb-f5f35c74251d/pipeline.log\">pipeline</a>"]},{"id":"58cb6ce0-4193-4b4d-8e7f-dd60298eda21","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"error","runTime":1754.251817,"created":"2025-09-02T15:30:19.645394","updated":"2025-09-02T15:30:19.645402","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58cb6ce0-4193-4b4d-8e7f-dd60298eda21\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58cb6ce0-4193-4b4d-8e7f-dd60298eda21/pipeline.log\">pipeline</a>"]},{"id":"6f4bdb1f-ed92-4d6f-bc77-b6fb387f2358","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4884.165419,"created":"2025-09-02T14:41:28.806874","updated":"2025-09-02T14:41:28.806879","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6f4bdb1f-ed92-4d6f-bc77-b6fb387f2358\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6f4bdb1f-ed92-4d6f-bc77-b6fb387f2358/pipeline.log\">pipeline</a>"]},{"id":"73db3a03-d0db-4461-9d4f-3cda65f5065f","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":1093.952551,"created":"2025-09-02T15:46:33.077883","updated":"2025-09-02T15:46:33.077890","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/73db3a03-d0db-4461-9d4f-3cda65f5065f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/73db3a03-d0db-4461-9d4f-3cda65f5065f/pipeline.log\">pipeline</a>"]},{"id":"0c1595b3-979c-4613-8b14-2f57f11b0a8f","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":1561.903799,"created":"2025-09-02T15:41:41.165547","updated":"2025-09-02T15:41:41.165554","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0c1595b3-979c-4613-8b14-2f57f11b0a8f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0c1595b3-979c-4613-8b14-2f57f11b0a8f/pipeline.log\">pipeline</a>"]},{"id":"2e2a47ef-8532-4e63-955e-6b2f9e53464e","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2572.640182,"created":"2025-09-02T15:24:18.714687","updated":"2025-09-02T15:24:18.714694","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e2a47ef-8532-4e63-955e-6b2f9e53464e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e2a47ef-8532-4e63-955e-6b2f9e53464e/pipeline.log\">pipeline</a>"]},{"id":"b2783030-d786-4f71-af0c-7023ac800a29","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2461.870257,"created":"2025-09-02T15:29:23.794225","updated":"2025-09-02T15:29:23.794233","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2783030-d786-4f71-af0c-7023ac800a29\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2783030-d786-4f71-af0c-7023ac800a29/pipeline.log\">pipeline</a>"]},{"id":"0af8359e-0c29-4341-bac2-8beed9ef7815","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":712.689474,"created":"2025-09-02T16:00:41.405383","updated":"2025-09-02T16:00:41.405388","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0af8359e-0c29-4341-bac2-8beed9ef7815\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0af8359e-0c29-4341-bac2-8beed9ef7815/pipeline.log\">pipeline</a>"]},{"id":"9ac97ebf-2b08-4263-8b63-70285c504135","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1398.929993,"created":"2025-09-02T15:53:57.779601","updated":"2025-09-02T15:53:57.779608","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9ac97ebf-2b08-4263-8b63-70285c504135\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9ac97ebf-2b08-4263-8b63-70285c504135/pipeline.log\">pipeline</a>"]},{"id":"f7650105-72d7-4259-86b6-aeedf4d7f174","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1193.282285,"created":"2025-09-02T16:00:46.264387","updated":"2025-09-02T16:00:46.264393","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f7650105-72d7-4259-86b6-aeedf4d7f174\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f7650105-72d7-4259-86b6-aeedf4d7f174/pipeline.log\">pipeline</a>"]},{"id":"818c4d4d-03a0-4bae-a98e-f7e224a4dea1","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":4740.841482,"created":"2025-09-02T15:02:36.730525","updated":"2025-09-02T15:02:36.730531","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/818c4d4d-03a0-4bae-a98e-f7e224a4dea1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/818c4d4d-03a0-4bae-a98e-f7e224a4dea1/pipeline.log\">pipeline</a>"]},{"id":"007a65f4-4caa-4bec-9d01-6dcf6a863bec","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":3336.311799,"created":"2025-09-02T15:28:07.892697","updated":"2025-09-02T15:28:07.892703","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/007a65f4-4caa-4bec-9d01-6dcf6a863bec\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/007a65f4-4caa-4bec-9d01-6dcf6a863bec/pipeline.log\">pipeline</a>"]},{"id":"e66b0004-0ed3-47ea-932e-74a9d996062c","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1183.2918,"created":"2025-09-02T16:06:51.043223","updated":"2025-09-02T16:06:51.043231","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e66b0004-0ed3-47ea-932e-74a9d996062c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e66b0004-0ed3-47ea-932e-74a9d996062c/pipeline.log\">pipeline</a>"]},{"id":"be8cb7b3-4719-4e36-a0c5-9eb010c6ad2d","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":3243.116368,"created":"2025-09-02T15:34:47.181043","updated":"2025-09-02T15:34:47.181049","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/be8cb7b3-4719-4e36-a0c5-9eb010c6ad2d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/be8cb7b3-4719-4e36-a0c5-9eb010c6ad2d/pipeline.log\">pipeline</a>"]},{"id":"b9f640a6-726d-4622-805c-615625bf271d","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":3173.228193,"created":"2025-09-02T15:35:37.649952","updated":"2025-09-02T15:35:37.649958","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9f640a6-726d-4622-805c-615625bf271d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9f640a6-726d-4622-805c-615625bf271d/pipeline.log\">pipeline</a>"]},{"id":"f03ebf4d-a78b-4a01-b595-1a29c9c04e94","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":3113.945274,"created":"2025-09-02T15:44:03.636345","updated":"2025-09-02T15:44:03.636351","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f03ebf4d-a78b-4a01-b595-1a29c9c04e94\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f03ebf4d-a78b-4a01-b595-1a29c9c04e94/pipeline.log\">pipeline</a>"]},{"id":"3162fa69-516a-4e03-9117-02acfa9b2aee","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5011.174092,"created":"2025-09-02T15:16:24.124231","updated":"2025-09-02T15:16:24.124240","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3162fa69-516a-4e03-9117-02acfa9b2aee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3162fa69-516a-4e03-9117-02acfa9b2aee/pipeline.log\">pipeline</a>"]},{"id":"5cb36f6a-9566-4aca-bee7-e31e8d6d48a8","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":3093.156454,"created":"2025-09-02T15:49:11.527330","updated":"2025-09-02T15:49:11.527368","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5cb36f6a-9566-4aca-bee7-e31e8d6d48a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5cb36f6a-9566-4aca-bee7-e31e8d6d48a8/pipeline.log\">pipeline</a>"]},{"id":"1156b527-38ab-47a6-aef9-2440f1867987","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3166.093156,"created":"2025-09-02T15:53:22.035457","updated":"2025-09-02T15:53:22.035463","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1156b527-38ab-47a6-aef9-2440f1867987\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1156b527-38ab-47a6-aef9-2440f1867987/pipeline.log\">pipeline</a>"]},{"id":"041121ed-f499-46c0-a489-d21ad745897a","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":3619.05895,"created":"2025-09-02T15:53:49.418723","updated":"2025-09-02T15:53:49.418732","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/041121ed-f499-46c0-a489-d21ad745897a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/041121ed-f499-46c0-a489-d21ad745897a/pipeline.log\">pipeline</a>"]},{"id":"8c795335-741c-461a-b72d-60ac48c8ebee","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":3576.19857,"created":"2025-09-02T15:57:35.158876","updated":"2025-09-02T15:57:35.158885","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c795335-741c-461a-b72d-60ac48c8ebee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c795335-741c-461a-b72d-60ac48c8ebee/pipeline.log\">pipeline</a>"]},{"id":"6876f0a1-3cc3-48b1-ba74-e7a8789e9fbd","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":3559.999546,"created":"2025-09-02T16:00:47.561647","updated":"2025-09-02T16:00:47.561653","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6876f0a1-3cc3-48b1-ba74-e7a8789e9fbd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6876f0a1-3cc3-48b1-ba74-e7a8789e9fbd/pipeline.log\">pipeline</a>"]},{"id":"446fda8f-87f1-40a6-ab33-42fb8ea365e7","name":"RHEL8 - postgresql-container","runTime":4717.897115,"created":"2025-09-02T16:04:01.069705","updated":"2025-09-02T16:04:01.069713","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/446fda8f-87f1-40a6-ab33-42fb8ea365e7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/446fda8f-87f1-40a6-ab33-42fb8ea365e7/pipeline.log\">pipeline</a>"]}]} -->