### PR TITLE
Remove RHEL7, UBI7 and  scl enable from test suite

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -59,7 +59,7 @@ jobs:
               tmt_plan="rhel8-docker$"
             else
               if [ "${{ matrix.os }}" == "rhel9" ]; then
-                compose="RHEL-9.4.0-Nightly"
+                compose="RHEL-9.6.0-Nightly"
                 context="RHEL9"
                 tmt_plan="rhel9-docker$"
               else

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ This rule will run the testsuite scripts contained in the container source repos
 It expects the test to be available at `$gitroot/$version/test/run`
 Depends on `tag` as some tests might need to have the images tagged (s2i).
 
+`make test-pytest`
+Similar to `make test` but runs testsuite for container by PyTest, expected to be found at
+`$gitroot/$version/test/run-pytest`
+
+
 `make test-openshift-4`
 Similar to `make test` but runs testsuite for Openshift 4, expected to be found at
 `$gitroot/$version/test/run-openshift-remote-cluster`
@@ -53,7 +58,7 @@ for RHEL world please ask pkubat@redhat.com, phracek@redhat.com, or hhorak@redha
 
 E.g. command for the source generation into Fedora dist-repo
 `https://src.fedoraproject.org/container/nodejs` into main branch is:
-`make betka TARGET=fedora VERSIONS=20`
+`make betka TARGET=fedora VERSIONS=24`
 
 The sources are not generated directly into dist-git repository,
 but into created `results` directory.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Names of the directories in which the Dockerfiles are contained. Needs to be def
 Dockerfile for the scripts to know which versions to build.
 
 `OS`
-OS version you want to build the images for. Currently the scripts are able to build for
-centos (default), c9s, c10s, rhel8, rhel9, rhel10, and fedora.
+OS version you want to build the images for. Currently, the scripts are able to build for
+c9s, c10s, rhel8, rhel9, rhel10, and fedora.
 
 `SKIP_SQUASH`
 When set to 1 the build script will skip the squash phase of the build.
@@ -122,7 +122,7 @@ how scripts in this repo work:
 
 `.exclude-<OS>`
 If this file exists, the tooling will not run the build and tests for the specific Dockerfile.
-For example, if `.exclude-rhel8` file exists, the `Dockerfile.rhel8` will not be expected
+For example, if `.exclude-rhel10` file exists, the `Dockerfile.rhel10` will not be expected
 in the same directory, build and tests will be skipped.
 Content of the file is not important at this point.
 
@@ -130,9 +130,9 @@ Content of the file is not important at this point.
 This file is useful if we need to work with RPMs that are not available publically yet.
 Content of the file is not important at this point.
 If such a file exists in the repository, then the building scripts will take a look
-at a correspondent variable, e.g.  DEVEL_REPO_rhel8, and will use the repository file
+at a correspondent variable, e.g.  DEVEL_REPO_rhel10, and will use the repository file
 defined by that variable.
-That means that definition of the DEVEL_REPO_rhel8 variable is a responsibility of
+That means that definition of the DEVEL_REPO_rhel10 variable is a responsibility of
 the test/CI environment.
 
 `.build-args-<OS>`

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,6 @@ parse_output ()
 
 analyze_logs_by_logdetective() {
   # logdetective should not break the build functionality
-  set +e
   local log_file_name="$1"
   echo "Sending failed log by fpaste command to paste bin."
   paste_bin_link=$(fpaste "$log_file_name")
@@ -87,10 +86,8 @@ analyze_logs_by_logdetective() {
     echo "ERROR: Failed to analyze log file by logdetective server."
     cat "${logdetective_build_file}"
     echo "-------- LOGDETECTIVE BUILD LOG ANALYSIS FAILED --------"
-    set -e
     return
   fi
-  set -e
   jq -rC '.explanation.text' < "${logdetective_build_file}"
   # This part of code is from https://github.com/teemtee/tmt/blob/main/tmt/steps/scripts/tmt-file-submit
   if [ -z "$TMT_TEST_PIDFILE" ]; then
@@ -247,8 +244,10 @@ function docker_build_with_version {
   else
     if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
       # Do not fail in case of sending log to pastebin or logdetective fails.
+      set +e
       echo "Analyse logs by logdetective, why it failed."
       analyze_logs_by_logdetective "${tmp_file}"
+      set -e
     fi
     exit 1
   fi

--- a/shared-scripts/core/opt/app-root/etc/scl_enable
+++ b/shared-scripts/core/opt/app-root/etc/scl_enable
@@ -1,2 +1,0 @@
-# This file contains automatic SCL enablement.
-unset BASH_ENV PROMPT_COMMAND ENV

--- a/shared-scripts/core/usr/bin/prepare-yum-repositories
+++ b/shared-scripts/core/usr/bin/prepare-yum-repositories
@@ -17,7 +17,7 @@ set -ex
 # but might be used if we need to change this behaviour.
 # Once we realize there are real use cases for using those variables, we should
 # document them properly.
-DEFAULT_REPOS=${DEFAULT_REPOS:-"rhel-7-server-rpms rhel-7-server-optional-rpms"}
+DEFAULT_REPOS=${DEFAULT_REPOS:-"rhel-10-server-baseos-rpms rhel-10-server-appstream-rpms"}
 SKIP_REPOS_ENABLE=${SKIP_REPOS_ENABLE:-false}
 SKIP_REPOS_DISABLE=${SKIP_REPOS_DISABLE:-false}
 

--- a/test-lib-openshift.sh
+++ b/test-lib-openshift.sh
@@ -900,7 +900,7 @@ ct_os_test_response_internal() {
   local status
   local response_code
   local response_file
-  local util_image_name='registry.access.redhat.com/ubi7/ubi'
+  local util_image_name='registry.access.redhat.com/ubi10/ubi'
 
   response_file=$(mktemp /tmp/ct_test_response_XXXXXX)
   ct_os_deploy_cmd_image "${util_image_name}"

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,6 @@ failed_version() {
 analyze_logs_by_logdetective() {
   # logdetective should not break the test functionality
   # Therefore `set +e` is setup
-  set +e
   local log_file_name="$1"
   echo "Sending failed log by fpaste command to paste bin."
   paste_bin_link=$(fpaste "$log_file_name")
@@ -47,16 +46,12 @@ analyze_logs_by_logdetective() {
     echo "ERROR: Failed to analyze log file by logdetective server."
     cat "${logdetective_test_file}"
     echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FAILED --------"
-    # Let's switch it back
-    set -e
     return
   fi
   jq -rC '.explanation.text' < "${logdetective_test_file}"
   # This part of code is from https://github.com/teemtee/tmt/blob/main/tmt/steps/scripts/tmt-file-submit
   if [ -z "$TMT_TEST_PIDFILE" ]; then
     echo "File submit to data dir can be used only in the context of a running test."
-    # Let's switch it back
-    set -e
     return
   fi
   # This variable is set by tmt
@@ -64,8 +59,6 @@ analyze_logs_by_logdetective() {
   cp -f "${logdetective_test_file}" "$TMT_TEST_DATA"
   echo "File '${logdetective_test_file}' stored to '$TMT_TEST_DATA'."
   echo "-------- LOGDETECTIVE TEST LOG ANALYSIS FINISHED --------"
-  # Let's switch it back
-  set -e
 }
 
 # This adds backwards compatibility if only single version needs to be testing
@@ -99,7 +92,10 @@ for dir in ${VERSIONS}; do
     cat "${tmp_file}"
     if [[ "$ret_code" != "0" ]]; then
       if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+        set +e
         analyze_logs_by_logdetective "$tmp_file"
+        # Let's switch it back
+        set -e
       fi
     fi
     failed_version "$ret_code" "$dir"
@@ -132,7 +128,10 @@ for dir in ${VERSIONS}; do
       cat "${tmp_file}"
       if [[ "$ret_code" != "0" ]]; then
         if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+          set +e
           analyze_logs_by_logdetective "$tmp_file"
+          # Let's switch it back
+          set -e
         fi
       fi
       failed_version "$ret_code" "$dir"

--- a/tests/check_imagestreams.sh
+++ b/tests/check_imagestreams.sh
@@ -12,4 +12,4 @@ test $? -eq 0
 echo "This tests check if 'show_all_imagestreams.py' returns proper output"
 output=$("${PYTHON-python3}" "$show_all_imagestreams")
 test "${output#*"- latest -> 2.4"}" != "$output" && echo "latest found in the output"
-test "${output#*"- 2.4-el8 -> registry.redhat.io/rhel8/httpd-24"}" != "$output" && echo "2.4 found in the output"
+test "${output#*"- 2.4-el10 -> registry.redhat.io/rhel10/httpd-24"}" != "$output" && echo "2.4 found in the output"

--- a/tests/imagestreams/testing_file.json
+++ b/tests/imagestreams/testing_file.json
@@ -46,7 +46,7 @@
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "2.4-el8"
+        "name": "2.4-el10"
       }
     ]
   }

--- a/tests/imagestreams/testing_file.json
+++ b/tests/imagestreams/testing_file.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -30,7 +30,7 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server 2.4",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -41,7 +41,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/rhel8/httpd-24"
+          "name": "registry.redhat.io/rhel10/httpd-24"
         },
         "referencePolicy": {
           "type": "Local"

--- a/tests/test-lib/public_image_name
+++ b/tests/test-lib/public_image_name
@@ -5,8 +5,8 @@ set -e
 . test-lib.sh
 
 combinations="c9s:quay.io/sclorg/postgresql-15-c9s
-rhel8:registry.redhat.io/rhel8/postgresql-15
 rhel9:registry.redhat.io/rhel9/postgresql-15
+rhel10:registry.redhat.io/rhel10/postgresql-15
 "
 
 for c in $combinations; do


### PR DESCRIPTION
This pull request is separated to several commit:

- Remove RHEL7, UBI7 and centos sentences in this test suite
- Update compose from RHEL-9.4-Nightly to RHEL-9.6-Nightly
- Remove two functions `ct_check_exec_env_vars` annd `ct_check_scl_enable_vars`
- Turn off failed in case of analysis is sent to logdetective. We do not want to fail in case of something happens
- Replace RHEL8 -> RHEL10 in check_imagestreams.sh

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"3252716981"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3252950480","data":[{"id":"f85aacf6-fbf0-4060-97ed-4c670137e0f5","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":945.005797,"created":"2025-09-04T09:59:00.086767","updated":"2025-09-04T09:59:00.086774","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f85aacf6-fbf0-4060-97ed-4c670137e0f5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f85aacf6-fbf0-4060-97ed-4c670137e0f5/pipeline.log\">pipeline</a>"]},{"id":"3c6f7c67-8b3b-4e89-b2db-573a82dd2ed9","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1031.669256,"created":"2025-09-04T09:58:59.109461","updated":"2025-09-04T09:58:59.109469","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c6f7c67-8b3b-4e89-b2db-573a82dd2ed9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c6f7c67-8b3b-4e89-b2db-573a82dd2ed9/pipeline.log\">pipeline</a>"]},{"id":"2748f3b7-89de-4818-8456-6db0cb2b60c0","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1150.835139,"created":"2025-09-04T09:58:58.851554","updated":"2025-09-04T09:58:58.851560","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2748f3b7-89de-4818-8456-6db0cb2b60c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2748f3b7-89de-4818-8456-6db0cb2b60c0/pipeline.log\">pipeline</a>"]},{"id":"212e09a9-40af-4231-938d-791f94358ba7","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1294.815419,"created":"2025-09-04T09:59:52.884421","updated":"2025-09-04T09:59:52.884428","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/212e09a9-40af-4231-938d-791f94358ba7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/212e09a9-40af-4231-938d-791f94358ba7/pipeline.log\">pipeline</a>"]},{"id":"b2efbd8f-51f7-4741-ac41-26b2979e1f8a","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1369.761782,"created":"2025-09-04T09:59:00.021442","updated":"2025-09-04T09:59:00.021449","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b2efbd8f-51f7-4741-ac41-26b2979e1f8a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b2efbd8f-51f7-4741-ac41-26b2979e1f8a/pipeline.log\">pipeline</a>"]},{"id":"464c2725-f3bf-4858-87f9-fa356bda2587","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1405.986404,"created":"2025-09-04T09:59:05.920273","updated":"2025-09-04T09:59:05.920280","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/464c2725-f3bf-4858-87f9-fa356bda2587\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/464c2725-f3bf-4858-87f9-fa356bda2587/pipeline.log\">pipeline</a>"]},{"id":"9bf063bc-c172-4631-8ff3-1f01cf121f44","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1397.889486,"created":"2025-09-04T09:58:58.770061","updated":"2025-09-04T09:58:58.770069","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bf063bc-c172-4631-8ff3-1f01cf121f44\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bf063bc-c172-4631-8ff3-1f01cf121f44/pipeline.log\">pipeline</a>"]},{"id":"31082d0b-93fd-4bac-a4c1-a58d17413fc3","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1488.880142,"created":"2025-09-04T09:59:00.102485","updated":"2025-09-04T09:59:00.102492","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/31082d0b-93fd-4bac-a4c1-a58d17413fc3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/31082d0b-93fd-4bac-a4c1-a58d17413fc3/pipeline.log\">pipeline</a>"]},{"id":"96b139d3-a70a-4d7e-90d3-865510071d18","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1636.24751,"created":"2025-09-04T09:58:59.898204","updated":"2025-09-04T09:58:59.898210","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/96b139d3-a70a-4d7e-90d3-865510071d18\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/96b139d3-a70a-4d7e-90d3-865510071d18/pipeline.log\">pipeline</a>"]},{"id":"90d66951-94ce-4175-b09e-10901bcb8a22","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1633.216863,"created":"2025-09-04T09:58:59.949467","updated":"2025-09-04T09:58:59.949475","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/90d66951-94ce-4175-b09e-10901bcb8a22\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/90d66951-94ce-4175-b09e-10901bcb8a22/pipeline.log\">pipeline</a>"]},{"id":"f99d6fbe-f028-43fd-b34b-d08103100f89","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1689.996435,"created":"2025-09-04T09:59:00.026062","updated":"2025-09-04T09:59:00.026070","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f99d6fbe-f028-43fd-b34b-d08103100f89\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f99d6fbe-f028-43fd-b34b-d08103100f89/pipeline.log\">pipeline</a>"]},{"id":"b2ea973b-4d5f-4b30-9634-0da66e963910","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1738.431444,"created":"2025-09-04T09:58:59.795102","updated":"2025-09-04T09:58:59.795138","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2ea973b-4d5f-4b30-9634-0da66e963910\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2ea973b-4d5f-4b30-9634-0da66e963910/pipeline.log\">pipeline</a>"]},{"id":"137f8403-c7a7-4d78-a41a-a4d9af284075","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1691.5992,"created":"2025-09-04T09:59:01.530558","updated":"2025-09-04T09:59:01.530567","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/137f8403-c7a7-4d78-a41a-a4d9af284075\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/137f8403-c7a7-4d78-a41a-a4d9af284075/pipeline.log\">pipeline</a>"]},{"id":"92dd7919-0d4c-48a1-a874-bd9109f2e03c","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1873.976848,"created":"2025-09-04T09:59:02.023337","updated":"2025-09-04T09:59:02.023345","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/92dd7919-0d4c-48a1-a874-bd9109f2e03c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/92dd7919-0d4c-48a1-a874-bd9109f2e03c/pipeline.log\">pipeline</a>"]},{"id":"d98fd66e-b93b-4e0a-a532-c2dfdb10681f","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":742.130417,"created":"2025-09-04T10:19:19.449912","updated":"2025-09-04T10:19:19.449922","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d98fd66e-b93b-4e0a-a532-c2dfdb10681f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d98fd66e-b93b-4e0a-a532-c2dfdb10681f/pipeline.log\">pipeline</a>"]},{"id":"29610f82-f8ff-4b44-9f7d-4e6a36d3217f","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2059.752344,"created":"2025-09-04T09:58:58.190242","updated":"2025-09-04T09:58:58.190249","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29610f82-f8ff-4b44-9f7d-4e6a36d3217f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29610f82-f8ff-4b44-9f7d-4e6a36d3217f/pipeline.log\">pipeline</a>"]},{"id":"46da6e68-5697-4411-8e13-cb326276d271","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1090.558319,"created":"2025-09-04T10:15:25.116877","updated":"2025-09-04T10:15:25.116888","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46da6e68-5697-4411-8e13-cb326276d271\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46da6e68-5697-4411-8e13-cb326276d271/pipeline.log\">pipeline</a>"]},{"id":"48e9bda7-d387-47dd-8c18-69d415086658","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2231.78178,"created":"2025-09-04T09:59:00.144367","updated":"2025-09-04T09:59:00.144375","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/48e9bda7-d387-47dd-8c18-69d415086658\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/48e9bda7-d387-47dd-8c18-69d415086658/pipeline.log\">pipeline</a>"]},{"id":"5d2f6870-7ab6-48b0-9223-e7fdd9a3f5a1","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":824.071745,"created":"2025-09-04T10:23:25.083963","updated":"2025-09-04T10:23:25.083973","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5d2f6870-7ab6-48b0-9223-e7fdd9a3f5a1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5d2f6870-7ab6-48b0-9223-e7fdd9a3f5a1/pipeline.log\">pipeline</a>"]},{"id":"cc1b48ff-e08d-44ae-9144-42baba68d5b5","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":632.081621,"created":"2025-09-04T10:25:27.546404","updated":"2025-09-04T10:25:27.546412","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cc1b48ff-e08d-44ae-9144-42baba68d5b5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cc1b48ff-e08d-44ae-9144-42baba68d5b5/pipeline.log\">pipeline</a>"]},{"id":"e828640d-93ef-4727-9515-f637ba684708","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":729.64597,"created":"2025-09-04T10:23:22.614501","updated":"2025-09-04T10:23:22.614507","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e828640d-93ef-4727-9515-f637ba684708\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e828640d-93ef-4727-9515-f637ba684708/pipeline.log\">pipeline</a>"]},{"id":"cde8a373-ac0f-44af-8d80-b48516601ac9","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1115.199049,"created":"2025-09-04T10:17:20.706603","updated":"2025-09-04T10:17:20.706615","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cde8a373-ac0f-44af-8d80-b48516601ac9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cde8a373-ac0f-44af-8d80-b48516601ac9/pipeline.log\">pipeline</a>"]},{"id":"c03219ef-df8c-4e30-8fd1-ff129fdca4fc","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":610.409652,"created":"2025-09-04T10:27:21.332626","updated":"2025-09-04T10:27:21.332635","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c03219ef-df8c-4e30-8fd1-ff129fdca4fc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c03219ef-df8c-4e30-8fd1-ff129fdca4fc/pipeline.log\">pipeline</a>"]},{"id":"08c9dc9b-bbf2-4566-afab-a22af49ffcf0","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2482.450345,"created":"2025-09-04T09:59:00.874280","updated":"2025-09-04T09:59:00.874288","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/08c9dc9b-bbf2-4566-afab-a22af49ffcf0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/08c9dc9b-bbf2-4566-afab-a22af49ffcf0/pipeline.log\">pipeline</a>"]},{"id":"7b157977-0f56-47f2-be71-2086cca5a937","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2471.208855,"created":"2025-09-04T09:58:59.306167","updated":"2025-09-04T09:58:59.306177","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7b157977-0f56-47f2-be71-2086cca5a937\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7b157977-0f56-47f2-be71-2086cca5a937/pipeline.log\">pipeline</a>"]},{"id":"4cbf33b2-ed6a-4f46-92b3-0dc129ec19a4","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4631.758245,"created":"2025-09-04T09:58:59.942182","updated":"2025-09-04T09:58:59.942193","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cbf33b2-ed6a-4f46-92b3-0dc129ec19a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cbf33b2-ed6a-4f46-92b3-0dc129ec19a4/pipeline.log\">pipeline</a>"]},{"id":"68e75c79-785a-4c55-b7bb-b27e46bd2640","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":2947.194575,"created":"2025-09-04T10:27:26.377588","updated":"2025-09-04T10:27:26.377598","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/68e75c79-785a-4c55-b7bb-b27e46bd2640\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/68e75c79-785a-4c55-b7bb-b27e46bd2640/pipeline.log\">pipeline</a>"]},{"id":"7e768618-5a6d-42b2-b9cd-b23e4ced42fe","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4828.648996,"created":"2025-09-04T10:22:14.839384","updated":"2025-09-04T10:22:14.839390","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e768618-5a6d-42b2-b9cd-b23e4ced42fe\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e768618-5a6d-42b2-b9cd-b23e4ced42fe/pipeline.log\">pipeline</a>"]},{"id":"cbce96c4-c4c5-4d26-b30c-3387a8233a55","name":"RHEL8 - s2i-python-container","runTime":6374.229744,"created":"2025-09-04T09:58:59.873016","updated":"2025-09-04T09:58:59.873024","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbce96c4-c4c5-4d26-b30c-3387a8233a55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbce96c4-c4c5-4d26-b30c-3387a8233a55/pipeline.log\">pipeline</a>"]}]} -->