### PR TITLE
Remove usage .version and replace it with $dir variable.

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -32,7 +32,6 @@ for dir in ${VERSIONS}; do
   pushd "${dir}" > /dev/null
   IMAGE_ID=$(cat .image-id)
   name=$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID")
-  version=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
   # We need to check '.git' dir in root directory
   if [ -d "../.git" ] ; then
     commit_date=$(git show -s HEAD --format=%cd --date=short | sed 's/-//g')
@@ -42,10 +41,10 @@ for dir in ${VERSIONS}; do
   fi
 
   full_reg_name="$REGISTRY$name"
-  echo "-> Tagging image '$IMAGE_ID' as '$full_reg_name:$version' and '$full_reg_name:latest' and '$full_reg_name:$OS' and '$full_reg_name:$date_and_hash'"
+  echo "-> Tagging image '$IMAGE_ID' as '$full_reg_name:$dir' and '$full_reg_name:latest' and '$full_reg_name:$OS' and '$full_reg_name:$date_and_hash'"
 
   docker tag "$IMAGE_ID" "$full_reg_name:$OS"
-  docker tag "$IMAGE_ID" "$full_reg_name:$version"
+  docker tag "$IMAGE_ID" "$full_reg_name:$dir"
   docker tag "$IMAGE_ID" "$full_reg_name:latest"
   docker tag "$IMAGE_ID" "$full_reg_name:$date_and_hash"
 

--- a/test.sh
+++ b/test.sh
@@ -73,9 +73,8 @@ for dir in ${VERSIONS}; do
   pushd "${dir}" > /dev/null || exit 1
   IMAGE_ID=$(cat .image-id)
   export IMAGE_ID
-  IMAGE_VERSION=$(docker inspect -f "{{.Config.Labels.version}}" "$IMAGE_ID")
   # Kept also IMAGE_NAME as some tests might still use that.
-  IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$IMAGE_VERSION"
+  IMAGE_NAME="$(docker inspect -f "{{.Config.Labels.name}}" "$IMAGE_ID"):$dir"
     # shellcheck disable=SC2268
   if [ "${OS}" == "c9s" ] || [ "${OS}" == "c10s" ] || [ "${OS}" == "fedora" ]; then
     export IMAGE_NAME="$REGISTRY$IMAGE_NAME"


### PR DESCRIPTION
Remove usage .version and replace it with $dir variable.

The variable has format like:
1.24, 2.4-micro, 13.

So it can be used for tagging and testing.

As well as for test.sh it can be used

<!-- issue-commentator = {"comment-id":"3274330667"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3274584641","data":[{"id":"0636c116-e764-4029-8739-d920b82685a8","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1315.21045,"created":"2025-09-10T11:22:24.589806","updated":"2025-09-10T11:22:24.589815","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0636c116-e764-4029-8739-d920b82685a8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0636c116-e764-4029-8739-d920b82685a8/pipeline.log\">pipeline</a>"]},{"id":"4255141b-21ea-4b5e-9c28-39b7e8fe0b82","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1397.619587,"created":"2025-09-10T11:22:03.184727","updated":"2025-09-10T11:22:03.184737","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4255141b-21ea-4b5e-9c28-39b7e8fe0b82\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4255141b-21ea-4b5e-9c28-39b7e8fe0b82/pipeline.log\">pipeline</a>"]},{"id":"a832fa84-136e-40ad-aa1f-155f4b1e4649","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":860.844666,"created":"2025-09-10T11:30:18.288707","updated":"2025-09-10T11:30:18.288715","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a832fa84-136e-40ad-aa1f-155f4b1e4649\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a832fa84-136e-40ad-aa1f-155f4b1e4649/pipeline.log\">pipeline</a>"]},{"id":"9517c087-c67d-4298-8c26-63c3075b599f","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":792.036737,"created":"2025-09-10T11:33:37.778189","updated":"2025-09-10T11:33:37.778196","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9517c087-c67d-4298-8c26-63c3075b599f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9517c087-c67d-4298-8c26-63c3075b599f/pipeline.log\">pipeline</a>"]},{"id":"70b2bb33-6dd5-40f2-aaec-a096ae64b1c4","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":745.740868,"created":"2025-09-10T11:33:43.534523","updated":"2025-09-10T11:33:43.534530","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70b2bb33-6dd5-40f2-aaec-a096ae64b1c4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70b2bb33-6dd5-40f2-aaec-a096ae64b1c4/pipeline.log\">pipeline</a>"]},{"id":"db8f4587-736c-42cb-a995-f5833e0ed5eb","name":"RHEL10 - nginx-container","runTime":1075.200861,"created":"2025-09-30T10:52:29.849662","updated":"2025-09-30T10:52:29.849670","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/db8f4587-736c-42cb-a995-f5833e0ed5eb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/db8f4587-736c-42cb-a995-f5833e0ed5eb/pipeline.log\">pipeline</a>"]},{"id":"cef2c9f8-bb6c-47bf-81c4-1b7396753495","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2196.323892,"created":"2025-09-10T11:22:11.633076","updated":"2025-09-10T11:22:11.633084","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cef2c9f8-bb6c-47bf-81c4-1b7396753495\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cef2c9f8-bb6c-47bf-81c4-1b7396753495/pipeline.log\">pipeline</a>"]},{"id":"8625ae20-51fb-41be-9bc8-ec646c6fc214","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1615.948943,"created":"2025-09-10T11:33:38.915956","updated":"2025-09-10T11:33:38.915962","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8625ae20-51fb-41be-9bc8-ec646c6fc214\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8625ae20-51fb-41be-9bc8-ec646c6fc214/pipeline.log\">pipeline</a>"]},{"id":"f6e1a4b2-4824-4acc-bf2f-84ef178af77b","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2329.547579,"created":"2025-09-10T11:22:12.874906","updated":"2025-09-10T11:22:12.874912","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6e1a4b2-4824-4acc-bf2f-84ef178af77b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6e1a4b2-4824-4acc-bf2f-84ef178af77b/pipeline.log\">pipeline</a>"]},{"id":"4f9f3e22-3d9f-4889-8967-8667fa1b1ec8","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":991.798034,"created":"2025-09-10T11:44:22.326563","updated":"2025-09-10T11:44:22.326572","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4f9f3e22-3d9f-4889-8967-8667fa1b1ec8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4f9f3e22-3d9f-4889-8967-8667fa1b1ec8/pipeline.log\">pipeline</a>"]},{"id":"3666f444-ba2f-46ce-a19b-eb6e77509d2a","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":784.80318,"created":"2025-09-10T11:52:01.582825","updated":"2025-09-10T11:52:01.582831","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3666f444-ba2f-46ce-a19b-eb6e77509d2a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3666f444-ba2f-46ce-a19b-eb6e77509d2a/pipeline.log\">pipeline</a>"]},{"id":"c37e79ea-46b1-4637-9838-d17ada4f8220","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1148.037246,"created":"2025-09-10T11:46:07.080933","updated":"2025-09-10T11:46:07.080940","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c37e79ea-46b1-4637-9838-d17ada4f8220\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c37e79ea-46b1-4637-9838-d17ada4f8220/pipeline.log\">pipeline</a>"]},{"id":"9c69241e-5962-4844-b1e5-a48e12c0048f","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":849.391735,"created":"2025-09-10T11:50:40.498322","updated":"2025-09-10T11:50:40.498330","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9c69241e-5962-4844-b1e5-a48e12c0048f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9c69241e-5962-4844-b1e5-a48e12c0048f/pipeline.log\">pipeline</a>"]},{"id":"19d5105e-32fd-4827-8037-0fa27267cba2","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1192.055946,"created":"2025-09-10T11:48:08.495063","updated":"2025-09-10T11:48:08.495071","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/19d5105e-32fd-4827-8037-0fa27267cba2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/19d5105e-32fd-4827-8037-0fa27267cba2/pipeline.log\">pipeline</a>"]},{"id":"f3878bea-aed5-49e3-ad42-4b9a9ff1209e","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1770.80165,"created":"2025-09-10T11:48:14.333628","updated":"2025-09-10T11:48:14.333636","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3878bea-aed5-49e3-ad42-4b9a9ff1209e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3878bea-aed5-49e3-ad42-4b9a9ff1209e/pipeline.log\">pipeline</a>"]},{"id":"d8197490-bf00-4970-a404-754f1a9d2a1a","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2705.122837,"created":"2025-09-10T11:32:16.540314","updated":"2025-09-10T11:32:16.540321","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8197490-bf00-4970-a404-754f1a9d2a1a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8197490-bf00-4970-a404-754f1a9d2a1a/pipeline.log\">pipeline</a>"]},{"id":"e373849d-fca6-45c3-9a58-dffc126e49de","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2043.250531,"created":"2025-09-10T11:48:02.407983","updated":"2025-09-10T11:48:02.407991","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e373849d-fca6-45c3-9a58-dffc126e49de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e373849d-fca6-45c3-9a58-dffc126e49de/pipeline.log\">pipeline</a>"]},{"id":"8c34266a-9510-41c0-ae65-236d5ca363c8","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1105.212691,"created":"2025-09-10T12:06:52.118398","updated":"2025-09-10T12:06:52.118404","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c34266a-9510-41c0-ae65-236d5ca363c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c34266a-9510-41c0-ae65-236d5ca363c8/pipeline.log\">pipeline</a>"]},{"id":"d82e0cfb-c7a0-4b5c-9bcf-e5aab76b42fb","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1443.894365,"created":"2025-09-10T12:02:41.221635","updated":"2025-09-10T12:02:41.221642","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d82e0cfb-c7a0-4b5c-9bcf-e5aab76b42fb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d82e0cfb-c7a0-4b5c-9bcf-e5aab76b42fb/pipeline.log\">pipeline</a>"]},{"id":"73d0d565-bc66-4e91-9b9f-1c3be6b875ea","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1180.71612,"created":"2025-09-10T12:09:02.832881","updated":"2025-09-10T12:09:02.832889","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/73d0d565-bc66-4e91-9b9f-1c3be6b875ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/73d0d565-bc66-4e91-9b9f-1c3be6b875ea/pipeline.log\">pipeline</a>"]},{"id":"6cbf7259-bbb9-44a2-a788-5988279bbdce","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":740.100309,"created":"2025-09-10T12:16:49.363870","updated":"2025-09-10T12:16:49.363879","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6cbf7259-bbb9-44a2-a788-5988279bbdce\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6cbf7259-bbb9-44a2-a788-5988279bbdce/pipeline.log\">pipeline</a>"]},{"id":"79798ffb-d645-425e-99fd-d9b2bf85cb44","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1677.673229,"created":"2025-09-10T12:06:24.510014","updated":"2025-09-10T12:06:24.510022","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/79798ffb-d645-425e-99fd-d9b2bf85cb44\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/79798ffb-d645-425e-99fd-d9b2bf85cb44/pipeline.log\">pipeline</a>"]},{"id":"04ff2747-c735-4843-b45a-9c51c44f891d","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":1647.427261,"created":"2025-09-10T12:07:03.089690","updated":"2025-09-10T12:07:03.089696","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/04ff2747-c735-4843-b45a-9c51c44f891d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/04ff2747-c735-4843-b45a-9c51c44f891d/pipeline.log\">pipeline</a>"]},{"id":"e991c506-c55e-43b8-809f-2beeedf53fb1","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1216.995293,"created":"2025-09-10T12:14:51.582328","updated":"2025-09-10T12:14:51.582335","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e991c506-c55e-43b8-809f-2beeedf53fb1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e991c506-c55e-43b8-809f-2beeedf53fb1/pipeline.log\">pipeline</a>"]},{"id":"3c6fea32-4690-436e-b584-4265a788047a","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1373.805745,"created":"2025-09-10T12:18:34.976393","updated":"2025-09-10T12:18:34.976399","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c6fea32-4690-436e-b584-4265a788047a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c6fea32-4690-436e-b584-4265a788047a/pipeline.log\">pipeline</a>"]},{"id":"05931a7d-0bd5-4475-a5e9-e60e0617526a","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1787.795129,"created":"2025-09-10T12:14:59.547608","updated":"2025-09-10T12:14:59.547616","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/05931a7d-0bd5-4475-a5e9-e60e0617526a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/05931a7d-0bd5-4475-a5e9-e60e0617526a/pipeline.log\">pipeline</a>"]},{"id":"c702c6af-c112-4749-b6c1-3e6aa418d58b","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":5184.899642,"created":"2025-09-10T11:33:39.254455","updated":"2025-09-10T11:33:39.254463","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c702c6af-c112-4749-b6c1-3e6aa418d58b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c702c6af-c112-4749-b6c1-3e6aa418d58b/pipeline.log\">pipeline</a>"]},{"id":"0bb1ad19-6fbd-46e9-8a2a-d1e63cbe6df9","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3126.765112,"created":"2025-09-10T12:14:33.890957","updated":"2025-09-10T12:14:33.890965","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0bb1ad19-6fbd-46e9-8a2a-d1e63cbe6df9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0bb1ad19-6fbd-46e9-8a2a-d1e63cbe6df9/pipeline.log\">pipeline</a>"]},{"id":"1a9f510f-a798-4f62-9f45-099aa219950e","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":6690.07859,"created":"2025-09-10T11:32:06.559242","updated":"2025-09-10T11:32:06.559250","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a9f510f-a798-4f62-9f45-099aa219950e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a9f510f-a798-4f62-9f45-099aa219950e/pipeline.log\">pipeline</a>"]},{"id":"dba96ca0-0a28-4192-8215-8efa97604817","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":4697.696478,"created":"2025-09-10T12:08:26.979076","updated":"2025-09-10T12:08:26.979082","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dba96ca0-0a28-4192-8215-8efa97604817\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dba96ca0-0a28-4192-8215-8efa97604817/pipeline.log\">pipeline</a>"]}]} -->