### PR TITLE
Do not fail remove obsolete functions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 # SINGLE_VERSION - Specifies the image version - (must match with subdirectory in repo)
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
 
-set -eE
+set -E
 [ -n "${DEBUG:-}" ] && set -x
 
 # shellcheck shell=bash
@@ -21,53 +21,6 @@ error() { echo "ERROR: $*" ; false ; }
 
 trap 'echo "errexit on line $LINENO, $0" >&2' ERR
 
-
-# _parse_output_inner
-# -------------------
-# Helper function for 'parse_output'.
-# We need to avoid case statements in $() for older Bash versions (per issue
-# postgresql-container#35, mac ships with 3.2).
-# Example of problematic statement: echo $(case i in i) echo i;; esac)
-_parse_output_inner ()
-{
-    set -o pipefail
-    {
-        case $stream in
-        stdout|1|"")
-            eval "$command" | tee >(cat - >&"$stdout_fd")
-            ;;
-        stderr|2)
-            set +x # avoid stderr pollution
-            eval "$command" {free_fd}>&1 1>&"$stdout_fd" 2>&"$free_fd" | tee >(cat - >&"$stderr_fd")
-            ;;
-        esac
-        # Inherit correct exit status.
-        (exit "${PIPESTATUS[0]}")
-    } | eval "$filter"
-}
-
-
-# parse_output COMMAND FILTER_COMMAND OUTVAR [STREAM={stderr|stdout}]
-# -------------------------------------------------------------------
-# Parse standard (error) output of COMMAND with FILTER_COMMAND and store the
-# output into variable named OUTVAR.  STREAM might be 'stdout' or 'stderr',
-# defaults to 'stdout'.  The filtered output stays (live) printed to terminal.
-# This method doesn't create any explicit temporary files.
-# Defines:
-#   ${$OUTVAR}: Set to FILTER_COMMAND output.
-parse_output ()
-{
-  local command=$1 filter=$2 var=$3 stream=$4
-  echo "-> building using $command"
-  local raw_output='' rc=0
-  {
-      # shellcheck disable=SC2034
-      raw_output=$(_parse_output_inner)
-  } {stdout_fd}>&1 {stderr_fd}>&2
-  rc=$?
-  eval "$var=\$raw_output"
-  (exit $rc)
-}
 
 # "best-effort" cleanup of image
 function clean_image {
@@ -209,9 +162,7 @@ function docker_build_with_version {
   if [[ $ret_code != "0" ]]; then
     if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
       # Do not fail in case of sending log to pastebin or logdetective fails.
-      set +e
       analyze_logs_by_logdetective "${tmp_file}"
-      set -e
     fi
   else
     # Structure of log build is as follows:
@@ -226,12 +177,6 @@ function docker_build_with_version {
 
   rm -f "$tmp_file"
 
-  # shellcheck disable=SC2016
-
-#  parse_output 'docker build '"$BUILD_OPTIONS"' -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"' \
-#               "tail -n 1 | awk '/Successfully built|(^--> )?(Using cache )?[a-fA-F0-9]+$/{print \$NF}'" \
-#               IMAGE_ID
-#  analyze_logs_by_logdetective "$?" "${tmp_file}"
   echo "$IMAGE_ID" > .image-id
   tag_image
 }

--- a/build.sh
+++ b/build.sh
@@ -149,36 +149,48 @@ function docker_build_with_version {
   if [[ "$SKIP_SQUASH" -eq 0 ]] && [[ "$is_podman" -eq 1 ]]; then
     BUILD_OPTIONS+=" --squash"
   fi
-
-  command="docker build ${BUILD_OPTIONS} -f $dockerfile ${DOCKER_BUILD_CONTEXT}"
-  echo "-> building using $command"
-  set +x -o pipefail
-  tmp_file=$(mktemp "/tmp/${dir}-${OS}.XXXXXX")
-  $command 2>&1 | tee "$tmp_file"
-  ret_code=$?
-  set -x +o pipefail
-  echo "Return code from docker build is '$ret_code'."
-  last_row=$(< "$tmp_file" tail -n 1)
-  if [[ $ret_code != "0" ]]; then
-    if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
-      # Do not fail in case of sending log to pastebin or logdetective fails.
-      analyze_logs_by_logdetective "${tmp_file}"
+  i=1
+  while [ $i -le 2 ]; do
+    command="docker build ${BUILD_OPTIONS} -f $dockerfile ${DOCKER_BUILD_CONTEXT}"
+    echo "-> building using $command"
+    set +x -o pipefail
+    tmp_file=$(mktemp "/tmp/${dir}-${OS}.XXXXXX")
+    $command 2>&1 | tee "$tmp_file"
+    ret_code=$?
+    set -x +o pipefail
+    echo "Return code from docker build is '$ret_code'."
+    last_row=$(< "$tmp_file" tail -n 1)
+    if [[ $ret_code != "0" ]]; then
+      # In case of failure, we want to analyze the logs and send them to pastebin or logdetective.
+      # The failure can be ethel issue like network failure or registry failure.
+      # Red Hat Enterprise Linux 9 for x86_64 - AppStre 0.0  B/s |   0  B     00:00
+      # Errors during downloading metadata for repository 'rhel-9-for-x86_64-appstream-rpms':
+      #  - Curl error (56): Failure when receiving data from the peer for https:// [Received HTTP code 503 from proxy after CONNECT]
+      # Error: Failed to download metadata for repo 'rhel-9-for-x86_64-appstream-rpms':
+      if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+        # Do not fail in case of sending log to pastebin or logdetective fails.
+        analyze_logs_by_logdetective "${tmp_file}"
+      fi
+      ((i++))
+      sleep 5
+      echo "Retrying to build image for version $dir, attempt $i of 2."
+    else
+      # Structure of log build is as follows:
+      # COMMIT
+      # --> e191d12b5928
+      # e191d12b5928360dd6024fe80d31e08f994d42577f76b9b143e014749afc8ab4
+      # shellcheck disable=SC2016
+      if [[ "$last_row" =~ (^-->)?(Using cache )?[a-fA-F0-9]+$ ]]; then
+        IMAGE_ID="$last_row"
+      fi
+      echo "$IMAGE_ID" > .image-id
+      tag_image
+      break
     fi
-  else
-    # Structure of log build is as follows:
-    # COMMIT
-    # --> e191d12b5928
-    # e191d12b5928360dd6024fe80d31e08f994d42577f76b9b143e014749afc8ab4
-    # shellcheck disable=SC2016
-    if [[ "$last_row" =~ (^-->)?(Using cache )?[a-fA-F0-9]+$ ]]; then
-      IMAGE_ID="$last_row"
-    fi
-  fi
 
-  rm -f "$tmp_file"
+    rm -f "$tmp_file"
+  done
 
-  echo "$IMAGE_ID" > .image-id
-  tag_image
 }
 
 function tag_image {

--- a/build.sh
+++ b/build.sh
@@ -150,6 +150,7 @@ function docker_build_with_version {
     BUILD_OPTIONS+=" --squash"
   fi
   i=1
+  build_failed=1
   while [ $i -le 2 ]; do
     command="docker build ${BUILD_OPTIONS} -f $dockerfile ${DOCKER_BUILD_CONTEXT}"
     echo "-> building using $command"
@@ -185,11 +186,16 @@ function docker_build_with_version {
       fi
       echo "$IMAGE_ID" > .image-id
       tag_image
+      build_failed=0
       break
     fi
 
     rm -f "$tmp_file"
   done
+  if [[ $build_failed -ne 0 ]]; then
+    echo "-> Build failed for version $dir and OS $OS after 2 attempts, giving up."
+    exit 1
+  fi
 
 }
 

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,8 @@ error() { echo "ERROR: $*" ; false ; }
 
 trap 'echo "errexit on line $LINENO, $0" >&2' ERR
 
+MAX_BUILD_ATTEMPTS=2
+
 
 # "best-effort" cleanup of image
 function clean_image {
@@ -151,7 +153,7 @@ function docker_build_with_version {
   fi
   i=1
   build_failed=1
-  while [ $i -le 2 ]; do
+  while [ $i -le $MAX_BUILD_ATTEMPTS ]; do
     command="docker build ${BUILD_OPTIONS} -f $dockerfile ${DOCKER_BUILD_CONTEXT}"
     echo "-> building using $command"
     set +x -o pipefail
@@ -174,7 +176,7 @@ function docker_build_with_version {
       fi
       ((i++))
       sleep 5
-      echo "Retrying to build image for version $dir, attempt $i of 2."
+      echo "Retrying to build image for version $dir, attempt $i of $MAX_BUILD_ATTEMPTS."
     else
       # Structure of log build is as follows:
       # COMMIT

--- a/build.sh
+++ b/build.sh
@@ -233,7 +233,9 @@ fi
 echo "Built versions are: $dirs"
 
 for dir in ${dirs}; do
+  # shellcheck disable=SC2164
   pushd "${dir}" > /dev/null
   docker_build_with_version Dockerfile."$OS"
+  # shellcheck disable=SC2164
   popd > /dev/null
 done

--- a/common.mk
+++ b/common.mk
@@ -151,7 +151,7 @@ copy_md_files:
 remove_md_files:
 	@for version in $(VERSIONS); do \
 		if ls $$version/*.md 1> /dev/null 2>&1; then \
-			rm -v $$version/root/*.md ; \
+			rm -fv $$version/root/*.md ; \
 		fi ; \
 	done
 


### PR DESCRIPTION
This pull request removes already obsoleted funtions.
* remove `set -e` flag as we do not want to failed. We need to send a logs to logdetective
* Let's call build function twice in case of there is a failure with network or ethel issue.
* 
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4023397516"} -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now includes automatic retry logic to recover from transient failures (up to 2 attempts with 5-second intervals between retries).
  * Enhanced build failure detection and error handling with explicit termination when all retry attempts fail.
  * Updated file cleanup process to use force removal for improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4024152879","data":[{"id":"c5b8787f-24b7-46f7-83ea-4c709a6818c6","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1291.147187,"created":"2026-03-19T14:04:13.882405","updated":"2026-03-19T14:04:13.882415","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5b8787f-24b7-46f7-83ea-4c709a6818c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5b8787f-24b7-46f7-83ea-4c709a6818c6/pipeline.log\">pipeline</a>"]},{"id":"84059a6c-1f93-4823-8d13-3f87c4bf8cf4","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1575.912747,"created":"2026-03-19T13:45:35.982349","updated":"2026-03-19T13:45:35.982356","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/84059a6c-1f93-4823-8d13-3f87c4bf8cf4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/84059a6c-1f93-4823-8d13-3f87c4bf8cf4/pipeline.log\">pipeline</a>"]},{"id":"7735878c-7b2a-4c04-ae60-e764cf5c8069","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1018.984601,"created":"2026-03-19T14:13:54.810845","updated":"2026-03-19T14:13:54.810853","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7735878c-7b2a-4c04-ae60-e764cf5c8069\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7735878c-7b2a-4c04-ae60-e764cf5c8069/pipeline.log\">pipeline</a>"]},{"id":"b68bbef1-de9b-440e-856f-84ff9ed8d432","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1346.83647,"created":"2026-03-19T13:45:36.346733","updated":"2026-03-19T13:45:36.346740","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b68bbef1-de9b-440e-856f-84ff9ed8d432\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b68bbef1-de9b-440e-856f-84ff9ed8d432/pipeline.log\">pipeline</a>"]},{"id":"27bed249-ec86-4f37-a4e3-bc5d88026842","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1322.192333,"created":"2026-03-10T10:41:07.000208","updated":"2026-03-10T10:41:07.000215","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27bed249-ec86-4f37-a4e3-bc5d88026842\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27bed249-ec86-4f37-a4e3-bc5d88026842/pipeline.log\">pipeline</a>"]},{"id":"1c4820c9-1864-4c84-94dc-fd2b63e2df1d","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":753.287589,"created":"2026-03-19T13:46:18.414978","updated":"2026-03-19T13:46:18.414986","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c4820c9-1864-4c84-94dc-fd2b63e2df1d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c4820c9-1864-4c84-94dc-fd2b63e2df1d/pipeline.log\">pipeline</a>"]},{"id":"2d363e2e-0da1-46fc-8bdb-e5fab3be7f9a","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3793.671107,"created":"2026-03-19T14:18:02.651572","updated":"2026-03-19T14:18:02.651580","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2d363e2e-0da1-46fc-8bdb-e5fab3be7f9a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2d363e2e-0da1-46fc-8bdb-e5fab3be7f9a/pipeline.log\">pipeline</a>"]},{"id":"7bb59462-72d6-4164-9ef5-1072bec76675","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":726.126629,"created":"2026-03-19T13:49:53.732373","updated":"2026-03-19T13:49:53.732380","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7bb59462-72d6-4164-9ef5-1072bec76675\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7bb59462-72d6-4164-9ef5-1072bec76675/pipeline.log\">pipeline</a>"]},{"id":"c54cfa73-437f-44bc-a966-2529c2c7bdf3","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":923.288588,"created":"2026-03-19T14:22:19.644793","updated":"2026-03-19T14:22:19.644799","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c54cfa73-437f-44bc-a966-2529c2c7bdf3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c54cfa73-437f-44bc-a966-2529c2c7bdf3/pipeline.log\">pipeline</a>"]},{"id":"3b99b78d-8de0-419d-9918-07c388006a9d","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2277.690687,"created":"2026-03-23T14:41:15.194694","updated":"2026-03-23T14:41:15.194705","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3b99b78d-8de0-419d-9918-07c388006a9d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3b99b78d-8de0-419d-9918-07c388006a9d/pipeline.log\">pipeline</a>"]},{"id":"48784d9e-8156-4648-811b-1f3028d55378","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":850.891555,"created":"2026-03-19T13:45:34.566823","updated":"2026-03-19T13:45:34.566831","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/48784d9e-8156-4648-811b-1f3028d55378\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/48784d9e-8156-4648-811b-1f3028d55378/pipeline.log\">pipeline</a>"]},{"id":"c839fdab-7135-4a80-9a97-120e58317dbb","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":5691.986222,"created":"2026-03-23T14:41:17.063737","updated":"2026-03-23T14:41:17.063744","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c839fdab-7135-4a80-9a97-120e58317dbb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c839fdab-7135-4a80-9a97-120e58317dbb/pipeline.log\">pipeline</a>"]},{"id":"c2055fc9-fba9-4f57-a5c0-fa0019cf0c03","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":1076.71688,"created":"2026-03-19T14:16:06.913360","updated":"2026-03-19T14:16:06.913366","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c2055fc9-fba9-4f57-a5c0-fa0019cf0c03\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c2055fc9-fba9-4f57-a5c0-fa0019cf0c03/pipeline.log\">pipeline</a>"]},{"id":"f0a3e55d-e3dd-4745-be87-27f5a03c00d4","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1605.090439,"created":"2026-03-19T14:10:05.522176","updated":"2026-03-19T14:10:05.522184","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0a3e55d-e3dd-4745-be87-27f5a03c00d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0a3e55d-e3dd-4745-be87-27f5a03c00d4/pipeline.log\">pipeline</a>"]},{"id":"3abf9f84-be87-4507-8c18-0b7c0d0d67a4","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1649.906616,"created":"2026-03-19T13:45:34.822720","updated":"2026-03-19T13:45:34.822727","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3abf9f84-be87-4507-8c18-0b7c0d0d67a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3abf9f84-be87-4507-8c18-0b7c0d0d67a4/pipeline.log\">pipeline</a>"]},{"id":"60cf4063-8236-4faf-9832-74ceca1ad8ca","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":1263.604391,"created":"2026-03-19T13:45:35.266106","updated":"2026-03-19T13:45:35.266156","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/60cf4063-8236-4faf-9832-74ceca1ad8ca\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/60cf4063-8236-4faf-9832-74ceca1ad8ca/pipeline.log\">pipeline</a>"]},{"id":"09e49b0b-c727-4daa-9342-ab64d7cce6fe","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1001.985822,"created":"2026-03-19T13:45:34.826851","updated":"2026-03-19T13:45:34.826857","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/09e49b0b-c727-4daa-9342-ab64d7cce6fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/09e49b0b-c727-4daa-9342-ab64d7cce6fe/pipeline.log\">pipeline</a>"]},{"id":"d4a88622-a978-4110-a022-c288bea87ed9","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"passed","runTime":2298.889002,"created":"2026-03-19T13:45:35.327848","updated":"2026-03-19T13:45:35.327856","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4a88622-a978-4110-a022-c288bea87ed9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4a88622-a978-4110-a022-c288bea87ed9/pipeline.log\">pipeline</a>"]},{"id":"abcf80e4-80fc-4245-b3b0-f0444bde4146","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1075.477079,"created":"2026-03-19T13:45:35.894311","updated":"2026-03-19T13:45:35.894318","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/abcf80e4-80fc-4245-b3b0-f0444bde4146\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/abcf80e4-80fc-4245-b3b0-f0444bde4146/pipeline.log\">pipeline</a>"]},{"id":"1cd8ee76-b473-440f-ae88-c30f96579fb8","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1351.068073,"created":"2026-03-19T14:04:08.606987","updated":"2026-03-19T14:04:08.606994","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1cd8ee76-b473-440f-ae88-c30f96579fb8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1cd8ee76-b473-440f-ae88-c30f96579fb8/pipeline.log\">pipeline</a>"]},{"id":"7c074410-4942-4fa9-a752-b63af3fcafb8","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2404.242884,"created":"2026-03-19T13:45:36.342692","updated":"2026-03-19T13:45:36.342699","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c074410-4942-4fa9-a752-b63af3fcafb8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c074410-4942-4fa9-a752-b63af3fcafb8/pipeline.log\">pipeline</a>"]},{"id":"7ab95018-2bf5-47ab-9619-6073f4bb10d6","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1628.074277,"created":"2026-03-10T09:34:15.364804","updated":"2026-03-10T09:34:15.364812","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ab95018-2bf5-47ab-9619-6073f4bb10d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ab95018-2bf5-47ab-9619-6073f4bb10d6/pipeline.log\">pipeline</a>"]},{"id":"b3ae396c-b7f0-4c78-aea0-aa7c274d550b","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1900.741814,"created":"2026-03-19T13:45:36.165510","updated":"2026-03-19T13:45:36.165516","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3ae396c-b7f0-4c78-aea0-aa7c274d550b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3ae396c-b7f0-4c78-aea0-aa7c274d550b/pipeline.log\">pipeline</a>"]},{"id":"84741096-673c-40fe-968a-d5df14906cfe","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":955.852876,"created":"2026-03-19T14:13:59.366275","updated":"2026-03-19T14:13:59.366283","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/84741096-673c-40fe-968a-d5df14906cfe\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/84741096-673c-40fe-968a-d5df14906cfe/pipeline.log\">pipeline</a>"]},{"id":"88fbd137-54da-4922-8e4e-e0bcc7227c92","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1409.770615,"created":"2026-03-19T13:45:35.461854","updated":"2026-03-19T13:45:35.461860","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/88fbd137-54da-4922-8e4e-e0bcc7227c92\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/88fbd137-54da-4922-8e4e-e0bcc7227c92/pipeline.log\">pipeline</a>"]},{"id":"b5bba6fe-8dc0-4a3a-a670-cd579a9ee73f","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1732.593687,"created":"2026-03-19T13:45:36.603819","updated":"2026-03-19T13:45:36.603826","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b5bba6fe-8dc0-4a3a-a670-cd579a9ee73f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b5bba6fe-8dc0-4a3a-a670-cd579a9ee73f/pipeline.log\">pipeline</a>"]},{"id":"f55fce3a-a144-4481-8bba-419a6f1fc2fd","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2434.417374,"created":"2026-03-19T14:00:46.122870","updated":"2026-03-19T14:00:46.122879","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f55fce3a-a144-4481-8bba-419a6f1fc2fd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f55fce3a-a144-4481-8bba-419a6f1fc2fd/pipeline.log\">pipeline</a>"]},{"id":"f658a318-60a7-42e5-9cd0-ec77e970e4e8","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":4366.129238,"created":"2026-03-19T14:02:27.100521","updated":"2026-03-19T14:02:27.100530","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f658a318-60a7-42e5-9cd0-ec77e970e4e8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f658a318-60a7-42e5-9cd0-ec77e970e4e8/pipeline.log\">pipeline</a>"]},{"id":"7e0c450c-61eb-4457-8f02-a0346093dd6e","name":"RHEL9 - s2i-python-container","runTime":6786.456374,"created":"2026-03-23T14:41:15.320099","updated":"2026-03-23T14:41:15.320105","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7e0c450c-61eb-4457-8f02-a0346093dd6e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7e0c450c-61eb-4457-8f02-a0346093dd6e/pipeline.log\">pipeline</a>"]},{"id":"635c8168-8c9c-49fd-b582-17e2816ad482","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":6678.613617,"created":"2026-03-19T13:45:34.304449","updated":"2026-03-19T13:45:34.304459","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/635c8168-8c9c-49fd-b582-17e2816ad482\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/635c8168-8c9c-49fd-b582-17e2816ad482/pipeline.log\">pipeline</a>"]}]} -->