### PR TITLE
Add support for building and testing container images on C11S and RHEL11

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ Depends on `tag` as some tests might need to have the images tagged (s2i).
 Similar to `make test` but runs testsuite for container by PyTest, expected to be found at
 `$gitroot/$version/test/run-pytest`
 
-
-`make test-openshift-4`
-Similar to `make test` but runs testsuite for Openshift 4, expected to be found at
-`$gitroot/$version/test/run-openshift-remote-cluster`
-
 `make test-openshift-pytest`
 Similar to `make test` but runs PyTest test suite `https://github.com/sclorg/container-ci-suite` for Openshift 4,
 expected to be found at `$gitroot/$version/test/run-openshift-pytest`
@@ -101,7 +96,7 @@ Dockerfile for the scripts to know which versions to build.
 
 `OS`
 OS version you want to build the images for. Currently, the scripts are able to build for
-c9s, c10s, rhel8, rhel9, rhel10, and fedora.
+c9s, c10s, c11s, rhel8, rhel9, rhel10, rhel11, and fedora.
 
 `SKIP_SQUASH`
 When set to 1 the build script will skip the squash phase of the build.
@@ -171,7 +166,6 @@ Dependencies for testsuite:
 
 - /usr/bin/docker (either `docker` or `podman` + `podman-docker`)
 - git
-- go-md2man
 - make
 - source-to-image
 - shellcheck

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This script is used to build the OpenShift Docker images.
 #
-# OS - Specifies distribution - "rhel8", "rhel9", "rhel10", "c9s", "c10s" or "fedora"
+# OS - Specifies distribution - "rhel8", "rhel9", "rhel10", "rhel11", "c9s", "c10s" or "fedora"
 # VERSION - Specifies the image version - (must match with subdirectory in repo)
 # SINGLE_VERSION - Specifies the image version - (must match with subdirectory in repo)
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
@@ -170,7 +170,7 @@ function docker_build_with_version {
       # Errors during downloading metadata for repository 'rhel-9-for-x86_64-appstream-rpms':
       #  - Curl error (56): Failure when receiving data from the peer for https:// [Received HTTP code 503 from proxy after CONNECT]
       # Error: Failed to download metadata for repo 'rhel-9-for-x86_64-appstream-rpms':
-      if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+      if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]] || [[ "${OS}" == "rhel11" ]]; then
         # Do not fail in case of sending log to pastebin or logdetective fails.
         analyze_logs_by_logdetective "${tmp_file}"
       fi

--- a/common.mk
+++ b/common.mk
@@ -40,6 +40,9 @@ else ifeq ($(TARGET),rhel9)
 else ifeq ($(TARGET),rhel10)
 	OS := rhel10
 	DOCKERFILE ?= Dockerfile.rhel10
+else ifeq ($(TARGET),rhel11)
+	OS := rhel11
+	DOCKERFILE ?= Dockerfile.rhel11
 else ifeq ($(TARGET),fedora)
 	OS := fedora
 	DOCKERFILE ?= Dockerfile.fedora
@@ -48,9 +51,13 @@ else ifeq ($(TARGET),c9s)
 	OS := c9s
 	DOCKERFILE ?= Dockerfile.c9s
 	REGISTRY := quay.io/
-else
+else ifeq ($(TARGET),c10s)
 	OS := c10s
 	DOCKERFILE ?= Dockerfile.c10s
+	REGISTRY := quay.io/
+else
+	OS := c11s
+	DOCKERFILE ?= Dockerfile.c11s
 	REGISTRY := quay.io/
 endif
 

--- a/generate_version_table.py
+++ b/generate_version_table.py
@@ -7,10 +7,12 @@ from natsort import natsorted
 distro_names = {
     "c9s": ["CentOS Stream 9", "quay.io/sclorg/%s-c9s"],
     "c10s": ["CentOS Stream 10", "quay.io/sclorg/%s-c10s"],
+    "c11s": ["CentOS Stream 11", "quay.io/sclorg/%s-c11s"],
     "fedora": ["Fedora", "quay.io/fedora/%s"],
     "rhel8": ["RHEL 8", "registry.redhat.io/rhel8/%s"],
     "rhel9": ["RHEL 9", "registry.redhat.io/rhel9/%s"],
     "rhel10": ["RHEL 10", "registry.redhat.io/rhel10/%s"],
+    "rhel11": ["RHEL 11", "registry.redhat.io/rhel11/%s"],
 }
 version_regex = re.compile(r"^VERSIONS\s*=\s*(.*)$")
 docker_file_regex = re.compile(r"(?<=Dockerfile\.).+")

--- a/test-lib.sh
+++ b/test-lib.sh
@@ -738,10 +738,14 @@ ct_get_public_image_name() {
     public_image_name=$registry/rhel9/$base_image_name-${version//./}
   elif [ "$os" == "rhel10" ]; then
     public_image_name=$registry/rhel10/$base_image_name-${version//./}
+  elif [ "$os" == "rhel11" ]; then
+    public_image_name=$registry/rhel11/$base_image_name-${version//./}
   elif [ "$os" == "c9s" ]; then
     public_image_name=$registry/sclorg/$base_image_name-${version//./}-c9s
   elif [ "$os" == "c10s" ]; then
     public_image_name=$registry/sclorg/$base_image_name-${version//./}-c10s
+  elif [ "$os" == "c11s" ]; then
+    public_image_name=$registry/sclorg/$base_image_name-${version//./}-c11s
   fi
 
   echo "$public_image_name"

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ run_test_and_analyze_failed_logs() {
   ret_code=$?
   set +o pipefail
   if [[ "$ret_code" != "0" ]]; then
-    if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]; then
+    if [[ "${OS}" == "rhel8" ]] || [[ "${OS}" == "rhel9" ]] || [[ "${OS}" == "rhel10" ]]|| [[ "${OS}" == "rhel11" ]]; then
       analyze_logs_by_logdetective "$tmp_file"
     fi
   fi

--- a/tests/failures/check/v0/Dockerfile.c11s
+++ b/tests/failures/check/v0/Dockerfile.c11s
@@ -1,0 +1,2 @@
+FROM quay.io/sclorg/s2i-core-c10s
+LABEL name=test-image

--- a/tests/failures/check/v0/Dockerfile.rhel11
+++ b/tests/failures/check/v0/Dockerfile.rhel11
@@ -1,0 +1,2 @@
+FROM ubi10/s2i-core
+LABEL name=test-image

--- a/tests/failures/check/v0/Dockerfile.rhel11
+++ b/tests/failures/check/v0/Dockerfile.rhel11
@@ -1,2 +1,3 @@
+# As we do not have a RHEL11 container image yet, we need to use a RHEL10 image.
 FROM ubi10/s2i-core
 LABEL name=test-image


### PR DESCRIPTION
Add support for building and testing container images on C11S and RHEL11

In case in container source is Dockerfile.rhel11, then this pull request enables it.

No other chnages is done.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4250849056"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CentOS Stream 11 (c11s) and RHEL 11 (rhel11) in build and test infrastructure.
  * Extended test environment configuration to support new OS variants.
  * New container images available for the latest OS versions.

* **Documentation**
  * Updated supported OS/version identifiers in documentation to include c11s and rhel11.
  * Removed outdated build target references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4258715165","data":[{"id":"b5815916-adad-46c1-baaa-b70bc1badfba","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":655.08506,"created":"2026-04-16T08:47:49.822474","updated":"2026-04-16T08:47:49.822481","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b5815916-adad-46c1-baaa-b70bc1badfba\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b5815916-adad-46c1-baaa-b70bc1badfba/pipeline.log\">pipeline</a>"]},{"id":"bb841381-9e69-4cda-9921-e4a5951eb542","name":"CentOS Stream 11 - s2i-python-container","status":"complete","outcome":"passed","runTime":777.53872,"created":"2026-04-16T08:47:48.840834","updated":"2026-04-16T08:47:48.840840","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bb841381-9e69-4cda-9921-e4a5951eb542\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bb841381-9e69-4cda-9921-e4a5951eb542/pipeline.log\">pipeline</a>"]},{"id":"f6f8b3c1-c164-4e66-8040-d4b36fcb0f58","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":826.188975,"created":"2026-04-16T08:47:46.814685","updated":"2026-04-16T08:47:46.814691","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6f8b3c1-c164-4e66-8040-d4b36fcb0f58\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6f8b3c1-c164-4e66-8040-d4b36fcb0f58/pipeline.log\">pipeline</a>"]},{"id":"a642a3e2-9778-4cc4-b944-5ebdc8eadd4c","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"error","runTime":886.754562,"created":"2026-04-16T11:25:46.699942","updated":"2026-04-16T11:25:46.699947","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a642a3e2-9778-4cc4-b944-5ebdc8eadd4c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a642a3e2-9778-4cc4-b944-5ebdc8eadd4c/pipeline.log\">pipeline</a>"]},{"id":"4163051a-350d-437c-86be-12418aa3e5d2","name":"RHEL10 - s2i-perl-container","runTime":846.5414,"created":"2026-04-16T11:25:45.173566","updated":"2026-04-16T11:25:45.173574","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4163051a-350d-437c-86be-12418aa3e5d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4163051a-350d-437c-86be-12418aa3e5d2/pipeline.log\">pipeline</a>"]},{"id":"b3e09310-4b67-488c-8901-cc8bf451e571","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1078.371889,"created":"2026-04-16T08:47:47.210842","updated":"2026-04-16T08:47:47.210848","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3e09310-4b67-488c-8901-cc8bf451e571\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3e09310-4b67-488c-8901-cc8bf451e571/pipeline.log\">pipeline</a>"]},{"id":"3d491db7-d594-4f89-8ce1-eaa81cbdbbf1","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":1067.877337,"created":"2026-04-16T08:47:52.549235","updated":"2026-04-16T08:47:52.549243","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3d491db7-d594-4f89-8ce1-eaa81cbdbbf1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3d491db7-d594-4f89-8ce1-eaa81cbdbbf1/pipeline.log\">pipeline</a>"]},{"id":"b75abd20-e7c8-4639-bcb6-8722a3b08a5f","name":"RHEL11 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1150.906599,"created":"2026-04-16T08:47:47.580466","updated":"2026-04-16T08:47:47.580473","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b75abd20-e7c8-4639-bcb6-8722a3b08a5f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b75abd20-e7c8-4639-bcb6-8722a3b08a5f/pipeline.log\">pipeline</a>"]},{"id":"326f08d3-a825-48a1-9e71-8d1c9e2cfe56","name":"RHEL11 - nginx-container","status":"complete","outcome":"passed","runTime":1115.396201,"created":"2026-04-16T08:47:48.707587","updated":"2026-04-16T08:47:48.707594","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/326f08d3-a825-48a1-9e71-8d1c9e2cfe56\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/326f08d3-a825-48a1-9e71-8d1c9e2cfe56/pipeline.log\">pipeline</a>"]},{"id":"d3e6ec3d-0062-487f-8516-ce0a4b21eda0","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1379.913276,"created":"2026-04-16T08:47:48.301864","updated":"2026-04-16T08:47:48.301870","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d3e6ec3d-0062-487f-8516-ce0a4b21eda0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d3e6ec3d-0062-487f-8516-ce0a4b21eda0/pipeline.log\">pipeline</a>"]},{"id":"37cd8beb-f383-42aa-bbb0-937dfe9d0b4f","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1636.685801,"created":"2026-04-16T08:47:48.326874","updated":"2026-04-16T08:47:48.326881","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/37cd8beb-f383-42aa-bbb0-937dfe9d0b4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/37cd8beb-f383-42aa-bbb0-937dfe9d0b4f/pipeline.log\">pipeline</a>"]},{"id":"43ab9916-5642-4077-b9ff-147b3033b89f","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"error","runTime":872.864611,"created":"2026-04-16T09:00:22.878862","updated":"2026-04-16T09:00:22.878869","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/43ab9916-5642-4077-b9ff-147b3033b89f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/43ab9916-5642-4077-b9ff-147b3033b89f/pipeline.log\">pipeline</a>"]},{"id":"905fcd75-9b4e-432f-9722-f462e8bd32ce","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":728.982931,"created":"2026-04-16T09:02:30.142542","updated":"2026-04-16T09:02:30.142549","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/905fcd75-9b4e-432f-9722-f462e8bd32ce\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/905fcd75-9b4e-432f-9722-f462e8bd32ce/pipeline.log\">pipeline</a>"]},{"id":"5bcb350d-181c-48ee-9369-2ee71d0ff5a9","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1754.048062,"created":"2026-04-16T08:47:47.269635","updated":"2026-04-16T08:47:47.269644","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5bcb350d-181c-48ee-9369-2ee71d0ff5a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5bcb350d-181c-48ee-9369-2ee71d0ff5a9/pipeline.log\">pipeline</a>"]},{"id":"75b76c92-9768-4c01-acb9-eda211be901f","name":"CentOS Stream 11 - s2i-base-container","status":"complete","outcome":"passed","runTime":831.064352,"created":"2026-04-16T09:06:11.969526","updated":"2026-04-16T09:06:11.969534","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/75b76c92-9768-4c01-acb9-eda211be901f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/75b76c92-9768-4c01-acb9-eda211be901f/pipeline.log\">pipeline</a>"]},{"id":"165627cf-32f5-4aed-8040-9c3fd46851af","name":"CentOS Stream 11 - s2i-perl-container","status":"complete","outcome":"passed","runTime":819.348843,"created":"2026-04-16T09:08:07.872539","updated":"2026-04-16T09:08:07.872546","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/165627cf-32f5-4aed-8040-9c3fd46851af\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/165627cf-32f5-4aed-8040-9c3fd46851af/pipeline.log\">pipeline</a>"]},{"id":"1c7de145-5abd-41fa-aab3-0d96e0eb7af0","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2106.755734,"created":"2026-04-16T08:47:49.513285","updated":"2026-04-16T08:47:49.513291","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c7de145-5abd-41fa-aab3-0d96e0eb7af0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c7de145-5abd-41fa-aab3-0d96e0eb7af0/pipeline.log\">pipeline</a>"]},{"id":"fcf89d18-aabd-4e76-b881-2f31f5289780","name":"RHEL10 - nginx-container","status":"complete","outcome":"error","runTime":859.150364,"created":"2026-04-16T11:25:47.360020","updated":"2026-04-16T11:25:47.360025","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fcf89d18-aabd-4e76-b881-2f31f5289780\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fcf89d18-aabd-4e76-b881-2f31f5289780/pipeline.log\">pipeline</a>"]},{"id":"043f081a-6626-4efe-a19f-f3c1c5a9ef89","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":1249.178907,"created":"2026-04-16T09:02:11.026598","updated":"2026-04-16T09:02:11.026605","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/043f081a-6626-4efe-a19f-f3c1c5a9ef89\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/043f081a-6626-4efe-a19f-f3c1c5a9ef89/pipeline.log\">pipeline</a>"]},{"id":"51aa1e5c-1e74-4d1d-bd01-533b41d97f2d","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1380.539092,"created":"2026-04-16T09:02:15.478664","updated":"2026-04-16T09:02:15.478674","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/51aa1e5c-1e74-4d1d-bd01-533b41d97f2d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/51aa1e5c-1e74-4d1d-bd01-533b41d97f2d/pipeline.log\">pipeline</a>"]},{"id":"33a2f9b5-fdda-40ef-af44-701b83aeb416","name":"RHEL11 - s2i-base-container","status":"complete","outcome":"passed","runTime":1123.624056,"created":"2026-04-16T09:08:10.928040","updated":"2026-04-16T09:08:10.928047","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/33a2f9b5-fdda-40ef-af44-701b83aeb416\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/33a2f9b5-fdda-40ef-af44-701b83aeb416/pipeline.log\">pipeline</a>"]},{"id":"72f9c4a9-e205-48ec-b737-341e49bf8809","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2431.556277,"created":"2026-04-16T08:47:48.324272","updated":"2026-04-16T08:47:48.324280","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/72f9c4a9-e205-48ec-b737-341e49bf8809\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/72f9c4a9-e205-48ec-b737-341e49bf8809/pipeline.log\">pipeline</a>"]},{"id":"7b95e448-029c-412c-9b87-6515aa182b38","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":812.300043,"created":"2026-04-16T09:16:46.612783","updated":"2026-04-16T09:16:46.612791","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7b95e448-029c-412c-9b87-6515aa182b38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7b95e448-029c-412c-9b87-6515aa182b38/pipeline.log\">pipeline</a>"]},{"id":"a46ac664-ca18-431b-be6d-479d2a79338c","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1789.728687,"created":"2026-04-16T09:02:11.693840","updated":"2026-04-16T09:02:11.693846","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a46ac664-ca18-431b-be6d-479d2a79338c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a46ac664-ca18-431b-be6d-479d2a79338c/pipeline.log\">pipeline</a>"]},{"id":"51f2d140-1909-41d6-84fd-cfea26262b75","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":835.989441,"created":"2026-04-16T09:18:09.194743","updated":"2026-04-16T09:18:09.194751","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/51f2d140-1909-41d6-84fd-cfea26262b75\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/51f2d140-1909-41d6-84fd-cfea26262b75/pipeline.log\">pipeline</a>"]},{"id":"b514fa6a-d9d2-4ee3-b01e-6d7eecaaba96","name":"RHEL11 - postgresql-container","status":"complete","outcome":"passed","runTime":1130.948981,"created":"2026-04-16T09:12:11.803449","updated":"2026-04-16T09:12:11.803457","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b514fa6a-d9d2-4ee3-b01e-6d7eecaaba96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b514fa6a-d9d2-4ee3-b01e-6d7eecaaba96/pipeline.log\">pipeline</a>"]},{"id":"2b7292df-b2b7-4e00-be7d-3716653c81ce","name":"RHEL10 - postgresql-container","status":"complete","outcome":"error","runTime":852.040009,"created":"2026-04-16T11:25:45.371326","updated":"2026-04-16T11:25:45.371333","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b7292df-b2b7-4e00-be7d-3716653c81ce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b7292df-b2b7-4e00-be7d-3716653c81ce/pipeline.log\">pipeline</a>"]},{"id":"b3e6c9b3-73ce-4379-8bcf-91ddecf837d0","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2902.508826,"created":"2026-04-16T08:47:48.991405","updated":"2026-04-16T08:47:48.991410","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3e6c9b3-73ce-4379-8bcf-91ddecf837d0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b3e6c9b3-73ce-4379-8bcf-91ddecf837d0/pipeline.log\">pipeline</a>"]},{"id":"ac464a41-85aa-41cc-80d9-63589ffb59ae","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2307.330838,"created":"2026-04-16T09:04:13.324659","updated":"2026-04-16T09:04:13.324669","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ac464a41-85aa-41cc-80d9-63589ffb59ae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ac464a41-85aa-41cc-80d9-63589ffb59ae/pipeline.log\">pipeline</a>"]},{"id":"acd90958-882e-44ab-868d-d19c24a80752","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1247.016257,"created":"2026-04-16T09:22:24.851222","updated":"2026-04-16T09:22:24.851229","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/acd90958-882e-44ab-868d-d19c24a80752\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/acd90958-882e-44ab-868d-d19c24a80752/pipeline.log\">pipeline</a>"]},{"id":"46230135-c52a-428b-a4cf-29e1fd772c7d","name":"RHEL11 - s2i-python-container","status":"complete","outcome":"passed","runTime":1117.038128,"created":"2026-04-16T09:24:32.621141","updated":"2026-04-16T09:24:32.621151","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46230135-c52a-428b-a4cf-29e1fd772c7d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46230135-c52a-428b-a4cf-29e1fd772c7d/pipeline.log\">pipeline</a>"]},{"id":"8c1203ef-5a53-47cf-9c0a-e65d3192c7df","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1378.543812,"created":"2026-04-16T09:24:16.499071","updated":"2026-04-16T09:24:16.499078","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8c1203ef-5a53-47cf-9c0a-e65d3192c7df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8c1203ef-5a53-47cf-9c0a-e65d3192c7df/pipeline.log\">pipeline</a>"]},{"id":"87c2f141-02fc-4141-8c06-b1d24d02d50e","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3681.161333,"created":"2026-04-16T08:47:48.034770","updated":"2026-04-16T08:47:48.034779","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/87c2f141-02fc-4141-8c06-b1d24d02d50e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/87c2f141-02fc-4141-8c06-b1d24d02d50e/pipeline.log\">pipeline</a>"]},{"id":"354a0754-0944-467d-b55a-bef00f36d292","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1968.249597,"created":"2026-04-16T09:16:53.157460","updated":"2026-04-16T09:16:53.157466","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/354a0754-0944-467d-b55a-bef00f36d292\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/354a0754-0944-467d-b55a-bef00f36d292/pipeline.log\">pipeline</a>"]},{"id":"080888fd-e579-4485-bb41-a2c5d515ace8","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":4436.049215,"created":"2026-04-16T08:48:22.781217","updated":"2026-04-16T08:48:22.781225","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/080888fd-e579-4485-bb41-a2c5d515ace8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/080888fd-e579-4485-bb41-a2c5d515ace8/pipeline.log\">pipeline</a>"]},{"id":"0709bc65-4e44-4c2c-aec2-3b0b100b1370","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"passed","runTime":6574.712363,"created":"2026-04-16T08:47:47.040588","updated":"2026-04-16T08:47:47.040594","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0709bc65-4e44-4c2c-aec2-3b0b100b1370\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0709bc65-4e44-4c2c-aec2-3b0b100b1370/pipeline.log\">pipeline</a>"]},{"id":"a86792ee-591c-4398-9c39-27886878c963","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":5766.970539,"created":"2026-04-16T09:02:19.860216","updated":"2026-04-16T09:02:19.860224","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a86792ee-591c-4398-9c39-27886878c963\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a86792ee-591c-4398-9c39-27886878c963/pipeline.log\">pipeline</a>"]},{"id":"6befbb72-afd7-46ba-ac50-0bb77aa60d11","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":6579.297437,"created":"2026-04-16T09:16:08.678935","updated":"2026-04-16T09:16:08.678946","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6befbb72-afd7-46ba-ac50-0bb77aa60d11\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6befbb72-afd7-46ba-ac50-0bb77aa60d11/pipeline.log\">pipeline</a>"]}]} -->