### PR TITLE
Enable building and testing container-common-scripts with TMT/FMF plans for C11S and RHEL11

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         container-to-test: ["postgresql-container", "nginx-container", "s2i-perl-container", "s2i-python-container", "s2i-base-container" ]
-        os: ["fedora", "c9s", "rhel8", "rhel9", "c10s", "rhel10"]
+        os: ["fedora", "c9s", "rhel8", "rhel9", "c10s", "rhel10", "c11s", "rhel11"]
 
     if: |
       github.event.issue.pull_request
@@ -32,7 +32,7 @@ jobs:
           branch="master"
           tf_scope="private"
           tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-          if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "c9s" ] || [ "${{ matrix.os }}" == "c10s" ]; then
+          if [ "${{ matrix.os }}" == "fedora" ] || [ "${{ matrix.os }}" == "c9s" ] || [ "${{ matrix.os }}" == "c10s" ] || [ "${{ matrix.os }}" == "c11s" ]; then
             api_key=${{ secrets.TF_PUBLIC_API_KEY }}
             branch="main"
             tf_scope="public"
@@ -47,9 +47,16 @@ jobs:
                 context="CentOS Stream 9"
                 tmt_plan="/c9s"
               else
-                compose="CentOS-Stream-10"
-                context="CentOS Stream 10"
-                tmt_plan="/c10s"
+                if [ "${{ matrix.os }}" == "c10s" ]; then
+                  compose="CentOS-Stream-10"
+                  context="CentOS Stream 10"
+                  tmt_plan="/c10s"
+                else
+                  # TODO - update compose and context for c11s when it will be available in Testing Farm
+                  compose="CentOS-Stream-10"
+                  context="CentOS Stream 11"
+                  tmt_plan="/c11s"
+                fi
               fi
             fi
           else
@@ -63,9 +70,15 @@ jobs:
                 context="RHEL9"
                 tmt_plan="/rhel9-docker$"
               else
-                compose="RHEL-10-Nightly"
-                context="RHEL10"
-                tmt_plan="/rhel10-docker$"
+                if [ "${{ matrix.os }}" == "rhel10" ]; then
+                  compose="RHEL-10-Nightly"
+                  context="RHEL10"
+                  tmt_plan="/rhel10-docker$"
+                else
+                  # TODO - update compose and context for rhel11 when it will be available in Testing Farm
+                  compose="RHEL-10-Nightly"
+                  context="RHEL11"
+                  tmt_plan="/rhel11-docker$"
               fi
             fi
           fi

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -41,45 +41,38 @@ jobs:
               compose="Fedora-latest"
               context="Fedora"
               tmt_plan="/fedora"
+            elif [ "${{ matrix.os }}" == "c9s" ]; then
+              compose="CentOS-Stream-9"
+              context="CentOS Stream 9"
+              tmt_plan="/c9s"
+            elif [ "${{ matrix.os }}" == "c10s" ]; then
+                compose="CentOS-Stream-10"
+                context="CentOS Stream 10"
+                tmt_plan="/c10s"
             else
-              if [ "${{ matrix.os }}" == "c9s" ]; then
-                compose="CentOS-Stream-9"
-                context="CentOS Stream 9"
-                tmt_plan="/c9s"
-              else
-                if [ "${{ matrix.os }}" == "c10s" ]; then
-                  compose="CentOS-Stream-10"
-                  context="CentOS Stream 10"
-                  tmt_plan="/c10s"
-                else
-                  # TODO - update compose and context for c11s when it will be available in Testing Farm
-                  compose="CentOS-Stream-10"
-                  context="CentOS Stream 11"
-                  tmt_plan="/c11s"
-                fi
-              fi
+              # TODO - update compose and context for c11s when it will be available in Testing Farm
+              compose="CentOS-Stream-10"
+              context="CentOS Stream 11"
+              tmt_plan="/c11s"
             fi
           else
             if [ "${{ matrix.os }}" == "rhel8" ]; then
               compose="RHEL-8.10.0-Nightly"
               context="RHEL8"
               tmt_plan="/rhel8-docker$"
+            elif [ "${{ matrix.os }}" == "rhel9" ]; then
+              compose="RHEL-9.6.0-Nightly"
+              context="RHEL9"
+              tmt_plan="/rhel9-docker$"
+            elif [ "${{ matrix.os }}" == "rhel10" ]; then
+              compose="RHEL-10-Nightly"
+              context="RHEL10"
+              tmt_plan="/rhel10-docker$"
             else
-              if [ "${{ matrix.os }}" == "rhel9" ]; then
-                compose="RHEL-9.6.0-Nightly"
-                context="RHEL9"
-                tmt_plan="/rhel9-docker$"
-              else
-                if [ "${{ matrix.os }}" == "rhel10" ]; then
-                  compose="RHEL-10-Nightly"
-                  context="RHEL10"
-                  tmt_plan="/rhel10-docker$"
-                else
-                  # TODO - update compose and context for rhel11 when it will be available in Testing Farm
-                  compose="RHEL-10-Nightly"
-                  context="RHEL11"
-                  tmt_plan="/rhel11-docker$"
-              fi
+              # TODO - update compose and context for rhel11 when it will be available in Testing Farm
+              compose="RHEL-10-Nightly"
+              context="RHEL11"
+              tmt_plan="/rhel11-docker$"
             fi
           fi
           echo "api_key=$api_key" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Enable building and testing container-common-scripts with
TMT/FMF plans for C11S and RHEL11.

As c11s and RHEL11 compose are not available yet
let's use for now CentOS Stream 10 and RHEL10.

Later on we can easily update only compose.

This pull request block #423 

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4251196817"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI/CD testing infrastructure to support CentOS Linux Stream 11 (c11s) and Red Hat Enterprise Linux 11 (rhel11) operating systems, enhancing test coverage across additional Linux distribution versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4251644463","data":[{"id":"35bbe7b9-8ce1-49d6-b055-28a05498a677","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":716.68921,"created":"2026-04-15T11:24:03.341178","updated":"2026-04-15T11:24:03.341186","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/35bbe7b9-8ce1-49d6-b055-28a05498a677\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/35bbe7b9-8ce1-49d6-b055-28a05498a677/pipeline.log\">pipeline</a>"]},{"id":"5296d66e-dc05-402d-acec-c614d13d90d2","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":918.118593,"created":"2026-04-15T11:24:02.053798","updated":"2026-04-15T11:24:02.053804","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5296d66e-dc05-402d-acec-c614d13d90d2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5296d66e-dc05-402d-acec-c614d13d90d2/pipeline.log\">pipeline</a>"]},{"id":"7fa8e04e-9d70-44d4-a816-b955da09c967","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":917.616236,"created":"2026-04-15T11:24:37.329609","updated":"2026-04-15T11:24:37.329619","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7fa8e04e-9d70-44d4-a816-b955da09c967\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7fa8e04e-9d70-44d4-a816-b955da09c967/pipeline.log\">pipeline</a>"]},{"id":"ae3db4c7-9d80-4863-affd-89c50079c7c1","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1312.763957,"created":"2026-04-15T11:24:02.589048","updated":"2026-04-15T11:24:02.589057","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ae3db4c7-9d80-4863-affd-89c50079c7c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ae3db4c7-9d80-4863-affd-89c50079c7c1/pipeline.log\">pipeline</a>"]},{"id":"c6471673-032b-44fd-9baa-540bf95a8392","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":1271.686715,"created":"2026-04-15T11:24:02.806528","updated":"2026-04-15T11:24:02.806536","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c6471673-032b-44fd-9baa-540bf95a8392\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c6471673-032b-44fd-9baa-540bf95a8392/pipeline.log\">pipeline</a>"]},{"id":"e5e48e60-ac0b-4549-aabd-90eea3f57d5e","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":1299.672477,"created":"2026-04-15T11:24:01.734946","updated":"2026-04-15T11:24:01.734958","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5e48e60-ac0b-4549-aabd-90eea3f57d5e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5e48e60-ac0b-4549-aabd-90eea3f57d5e/pipeline.log\">pipeline</a>"]},{"id":"34108234-563d-42c2-835d-0a1968c32b2a","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":1330.43253,"created":"2026-04-15T11:24:05.034104","updated":"2026-04-15T11:24:05.034146","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/34108234-563d-42c2-835d-0a1968c32b2a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/34108234-563d-42c2-835d-0a1968c32b2a/pipeline.log\">pipeline</a>"]},{"id":"c9b7da8d-f7ad-41b1-861a-8b587da5b1ad","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1472.377185,"created":"2026-04-15T11:24:02.483360","updated":"2026-04-15T11:24:02.483366","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c9b7da8d-f7ad-41b1-861a-8b587da5b1ad\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c9b7da8d-f7ad-41b1-861a-8b587da5b1ad/pipeline.log\">pipeline</a>"]},{"id":"32443b06-4d96-405b-9c65-eedfc0c78908","name":"RHEL10 - postgresql-container","status":"complete","outcome":"passed","runTime":1713.496668,"created":"2026-04-15T11:24:02.365538","updated":"2026-04-15T11:24:02.365546","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32443b06-4d96-405b-9c65-eedfc0c78908\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32443b06-4d96-405b-9c65-eedfc0c78908/pipeline.log\">pipeline</a>"]},{"id":"bc54d8db-17ef-4fca-8a19-b8942badf20d","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1768.429772,"created":"2026-04-15T11:24:01.768185","updated":"2026-04-15T11:24:01.768192","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bc54d8db-17ef-4fca-8a19-b8942badf20d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bc54d8db-17ef-4fca-8a19-b8942badf20d/pipeline.log\">pipeline</a>"]},{"id":"9e610394-1bff-47fa-87ab-205982e86875","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1789.217748,"created":"2026-04-15T11:24:04.869541","updated":"2026-04-15T11:24:04.869549","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e610394-1bff-47fa-87ab-205982e86875\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e610394-1bff-47fa-87ab-205982e86875/pipeline.log\">pipeline</a>"]},{"id":"97811569-41f1-4961-ae1f-7a1bf1c7e9f6","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":758.969739,"created":"2026-04-15T11:40:52.931413","updated":"2026-04-15T11:40:52.931423","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/97811569-41f1-4961-ae1f-7a1bf1c7e9f6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/97811569-41f1-4961-ae1f-7a1bf1c7e9f6/pipeline.log\">pipeline</a>"]},{"id":"f0ed818f-adda-4220-83b9-fdbba21fd272","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2084.117842,"created":"2026-04-15T11:24:03.261720","updated":"2026-04-15T11:24:03.261729","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0ed818f-adda-4220-83b9-fdbba21fd272\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0ed818f-adda-4220-83b9-fdbba21fd272/pipeline.log\">pipeline</a>"]},{"id":"a244eead-81ba-400b-9560-3b52b9023f91","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1373.270749,"created":"2026-04-15T11:36:53.011708","updated":"2026-04-15T11:36:53.011716","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a244eead-81ba-400b-9560-3b52b9023f91\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a244eead-81ba-400b-9560-3b52b9023f91/pipeline.log\">pipeline</a>"]},{"id":"f5054218-b856-4e4b-8655-33aa6f4f20c9","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":1222.382089,"created":"2026-04-15T11:40:18.618865","updated":"2026-04-15T11:40:18.618871","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f5054218-b856-4e4b-8655-33aa6f4f20c9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f5054218-b856-4e4b-8655-33aa6f4f20c9/pipeline.log\">pipeline</a>"]},{"id":"294c5161-35c3-4596-84b6-81fac3247c0c","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2342.61136,"created":"2026-04-15T11:24:02.471858","updated":"2026-04-15T11:24:02.471866","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/294c5161-35c3-4596-84b6-81fac3247c0c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/294c5161-35c3-4596-84b6-81fac3247c0c/pipeline.log\">pipeline</a>"]},{"id":"1ff4985d-41b3-4f68-986a-aec82820e311","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":867.840769,"created":"2026-04-15T11:48:26.048481","updated":"2026-04-15T11:48:26.048487","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1ff4985d-41b3-4f68-986a-aec82820e311\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1ff4985d-41b3-4f68-986a-aec82820e311/pipeline.log\">pipeline</a>"]},{"id":"3bd1947c-bcd7-4bf9-ba60-fd8b33c8d2be","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"error","runTime":2483.788806,"created":"2026-04-15T11:24:01.469053","updated":"2026-04-15T11:24:01.469059","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bd1947c-bcd7-4bf9-ba60-fd8b33c8d2be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bd1947c-bcd7-4bf9-ba60-fd8b33c8d2be/pipeline.log\">pipeline</a>"]},{"id":"77326cbc-6915-4e78-af3f-cbb013c32b7d","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":1178.502516,"created":"2026-04-15T11:46:31.798745","updated":"2026-04-15T11:46:31.798750","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/77326cbc-6915-4e78-af3f-cbb013c32b7d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/77326cbc-6915-4e78-af3f-cbb013c32b7d/pipeline.log\">pipeline</a>"]},{"id":"720500ca-106f-4a28-9f51-fa0a459044df","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":1093.252394,"created":"2026-04-15T11:50:17.828604","updated":"2026-04-15T11:50:17.828612","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/720500ca-106f-4a28-9f51-fa0a459044df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/720500ca-106f-4a28-9f51-fa0a459044df/pipeline.log\">pipeline</a>"]},{"id":"a75a4d52-da99-4d43-a7aa-2014178f14c6","name":"RHEL9 - postgresql-container","status":"complete","outcome":"passed","runTime":2941.98288,"created":"2026-04-15T11:24:04.228648","updated":"2026-04-15T11:24:04.228658","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a75a4d52-da99-4d43-a7aa-2014178f14c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a75a4d52-da99-4d43-a7aa-2014178f14c6/pipeline.log\">pipeline</a>"]},{"id":"3285fddd-8274-4986-bce9-99b8dda9db2e","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1669.664351,"created":"2026-04-15T11:46:20.573513","updated":"2026-04-15T11:46:20.573519","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3285fddd-8274-4986-bce9-99b8dda9db2e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3285fddd-8274-4986-bce9-99b8dda9db2e/pipeline.log\">pipeline</a>"]},{"id":"7f8a08f5-14ac-4318-9a7d-47bbc7177589","name":"RHEL9 - nginx-container","status":"complete","outcome":"passed","runTime":1992.70451,"created":"2026-04-15T11:46:25.495068","updated":"2026-04-15T11:46:25.495076","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f8a08f5-14ac-4318-9a7d-47bbc7177589\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f8a08f5-14ac-4318-9a7d-47bbc7177589/pipeline.log\">pipeline</a>"]},{"id":"ba97516f-0598-4d70-a1fc-9d9f692c277e","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1608.477979,"created":"2026-04-15T11:54:28.175988","updated":"2026-04-15T11:54:28.175995","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba97516f-0598-4d70-a1fc-9d9f692c277e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba97516f-0598-4d70-a1fc-9d9f692c277e/pipeline.log\">pipeline</a>"]},{"id":"99dab562-d8ba-43fc-9a4a-aff0cff75532","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3700.251163,"created":"2026-04-15T11:24:03.335502","updated":"2026-04-15T11:24:03.335510","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/99dab562-d8ba-43fc-9a4a-aff0cff75532\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/99dab562-d8ba-43fc-9a4a-aff0cff75532/pipeline.log\">pipeline</a>"]},{"id":"f94a539b-5ca1-487b-aa52-161ab2fbfd9b","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":4151.093956,"created":"2026-04-15T11:24:01.880882","updated":"2026-04-15T11:24:01.880891","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f94a539b-5ca1-487b-aa52-161ab2fbfd9b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f94a539b-5ca1-487b-aa52-161ab2fbfd9b/pipeline.log\">pipeline</a>"]},{"id":"5aff8fc7-8d67-440d-b00a-f5612c0531f9","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2413.477495,"created":"2026-04-15T11:54:20.882412","updated":"2026-04-15T11:54:20.882418","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5aff8fc7-8d67-440d-b00a-f5612c0531f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5aff8fc7-8d67-440d-b00a-f5612c0531f9/pipeline.log\">pipeline</a>"]},{"id":"fa70ffcb-135a-4087-93ec-305888533ef0","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":5652.553029,"created":"2026-04-15T11:24:03.033228","updated":"2026-04-15T11:24:03.033235","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa70ffcb-135a-4087-93ec-305888533ef0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa70ffcb-135a-4087-93ec-305888533ef0/pipeline.log\">pipeline</a>"]},{"id":"68ad09a7-d06e-4187-8848-717d4104653f","name":"CentOS Stream 9 - s2i-python-container","status":"complete","outcome":"passed","runTime":6666.120479,"created":"2026-04-15T11:24:04.549755","updated":"2026-04-15T11:24:04.549763","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/68ad09a7-d06e-4187-8848-717d4104653f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/68ad09a7-d06e-4187-8848-717d4104653f/pipeline.log\">pipeline</a>"]},{"id":"a4cf714e-db57-4334-90b4-82da6dd08f6a","name":"RHEL9 - s2i-python-container","runTime":6764.179255,"created":"2026-04-15T11:24:05.788721","updated":"2026-04-15T11:24:05.788731","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4cf714e-db57-4334-90b4-82da6dd08f6a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4cf714e-db57-4334-90b4-82da6dd08f6a/pipeline.log\">pipeline</a>"]}]} -->