### PR TITLE
Add matching .fXX suffixes to generator.py

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -74,6 +74,7 @@ def filename_to_distro_config(
     - Dockerfile.rhelXX → rhel-XX-x86_64.yaml
     - Dockerfile.cXXs → centos-stream-XX-x86_64.yaml
     - Dockerfile.fedora → the newest fedora-XX-x86_64.yaml
+    - Dockerfile.fXX → the selected fedora-XX-x86_64.yaml
 
     If not found, empty string is returned indicating that the
     combination of distro and version is not included
@@ -81,6 +82,7 @@ def filename_to_distro_config(
     """
     rhel_match = re.match(r".*\.rhel(\d+)$", filename)
     centos_stream_match = re.match(r".*\.c(\d+)s$", filename)
+    fedora_match = re.match(r".*\.f(\d+)$", filename)
 
     if rhel_match:
         config = f"rhel-{rhel_match.group(1)}-x86_64.yaml"
@@ -96,9 +98,11 @@ def filename_to_distro_config(
             config = sorted_configs[0]
         else:
             config = ""
+    elif fedora_match:  # just for base and core images
+        config = f"fedora-{fedora_match.group(1)}-x86_64.yaml"
     else:
         raise RuntimeError(
-            f"File {filename} does not match any of the known suffixes: .rhelXX, .cXs, or .fedora"
+            f"File {filename} does not match any of the known suffixes: .rhelXX, .cXs, .fedora, or .fXX"
         )
 
     return config


### PR DESCRIPTION
Main purpose is to enable easy distgenification of the base and core containers. Added a new statement to filename_to_distro_config()

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4958803557"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fedora base and core image filenames using the `*.f<NUM>` format are now recognized correctly.
  * These filenames are now mapped to the appropriate Fedora distribution configuration for image generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"5090555108","data":[{"id":"bdd454d0-087d-4c7d-b597-53130c5f9333","name":"RHEL11 - postgresql-container","status":"complete","outcome":"error","runTime":454.397024,"created":"2026-07-27T12:30:35.600450","updated":"2026-07-27T12:30:35.600459","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdd454d0-087d-4c7d-b597-53130c5f9333\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdd454d0-087d-4c7d-b597-53130c5f9333/pipeline.log\">pipeline</a>"]},{"id":"b44eeef4-48d1-4045-835e-46bd710c5c63","name":"RHEL10 - postgresql-container","status":"complete","outcome":"error","runTime":442.968598,"created":"2026-07-27T12:30:37.057868","updated":"2026-07-27T12:30:37.057873","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b44eeef4-48d1-4045-835e-46bd710c5c63\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b44eeef4-48d1-4045-835e-46bd710c5c63/pipeline.log\">pipeline</a>"]},{"id":"bfe2ab39-18d3-421b-ada2-f4fc55f85e55","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"error","runTime":644.809264,"created":"2026-07-27T12:30:37.584910","updated":"2026-07-27T12:30:37.584919","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfe2ab39-18d3-421b-ada2-f4fc55f85e55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfe2ab39-18d3-421b-ada2-f4fc55f85e55/pipeline.log\">pipeline</a>"]},{"id":"7bf16fee-9b3e-41e5-b743-a8faf9998c1e","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"error","runTime":567.981428,"created":"2026-07-27T12:30:35.942579","updated":"2026-07-27T12:30:35.942587","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7bf16fee-9b3e-41e5-b743-a8faf9998c1e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7bf16fee-9b3e-41e5-b743-a8faf9998c1e/pipeline.log\">pipeline</a>"]},{"id":"242d1404-c180-41c3-b710-6440d7e93599","name":"RHEL9 - nginx-container","status":"complete","outcome":"error","runTime":425.249453,"created":"2026-07-27T12:54:55.489836","updated":"2026-07-27T12:54:55.489843","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/242d1404-c180-41c3-b710-6440d7e93599\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/242d1404-c180-41c3-b710-6440d7e93599/pipeline.log\">pipeline</a>"]},{"id":"6cd29161-1b3d-4058-955f-898d2b37cd12","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"error","runTime":1015.380679,"created":"2026-07-27T12:30:35.796491","updated":"2026-07-27T12:30:35.796498","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cd29161-1b3d-4058-955f-898d2b37cd12\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cd29161-1b3d-4058-955f-898d2b37cd12/pipeline.log\">pipeline</a>"]},{"id":"c6bdbec8-7bea-4db9-ba40-407ba6da34f5","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"error","runTime":432.492006,"created":"2026-07-27T12:38:59.840397","updated":"2026-07-27T12:38:59.840406","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6bdbec8-7bea-4db9-ba40-407ba6da34f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6bdbec8-7bea-4db9-ba40-407ba6da34f5/pipeline.log\">pipeline</a>"]},{"id":"1cdcdb77-6820-4d08-be5e-ec34301cfa15","name":"RHEL9 - postgresql-container","status":"complete","outcome":"error","runTime":736.604204,"created":"2026-07-27T12:30:35.995766","updated":"2026-07-27T12:30:35.995775","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1cdcdb77-6820-4d08-be5e-ec34301cfa15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1cdcdb77-6820-4d08-be5e-ec34301cfa15/pipeline.log\">pipeline</a>"]},{"id":"5681a8ad-59d8-41bc-b147-73b59b60dc06","name":"Fedora - s2i-base-container","status":"complete","outcome":"passed","runTime":781.181024,"created":"2026-07-27T12:30:37.801358","updated":"2026-07-27T12:30:37.801366","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5681a8ad-59d8-41bc-b147-73b59b60dc06\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5681a8ad-59d8-41bc-b147-73b59b60dc06/pipeline.log\">pipeline</a>"]},{"id":"ec25e7bb-758f-4bae-8478-d99d2a415414","name":"Fedora - nginx-container","status":"complete","outcome":"passed","runTime":761.531506,"created":"2026-07-27T12:30:36.936069","updated":"2026-07-27T12:30:36.936076","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ec25e7bb-758f-4bae-8478-d99d2a415414\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ec25e7bb-758f-4bae-8478-d99d2a415414/pipeline.log\">pipeline</a>"]},{"id":"edbc0a41-0860-440f-93fc-a9af780213e6","name":"CentOS Stream 11 - s2i-perl-container","status":"complete","outcome":"passed","runTime":803.177051,"created":"2026-07-27T12:43:53.710939","updated":"2026-07-27T12:43:53.710945","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/edbc0a41-0860-440f-93fc-a9af780213e6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/edbc0a41-0860-440f-93fc-a9af780213e6/pipeline.log\">pipeline</a>"]},{"id":"eedb36c0-eaa7-4df2-b4a6-ac5feb168c96","name":"RHEL11 - s2i-perl-container","status":"complete","outcome":"error","runTime":501.748668,"created":"2026-07-27T12:30:36.813938","updated":"2026-07-27T12:30:36.813945","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eedb36c0-eaa7-4df2-b4a6-ac5feb168c96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eedb36c0-eaa7-4df2-b4a6-ac5feb168c96/pipeline.log\">pipeline</a>"]},{"id":"ccadccd4-0068-42ee-a08c-5c601259c89e","name":"RHEL9 - s2i-python-container","status":"complete","outcome":"error","runTime":440.292131,"created":"2026-07-27T12:54:55.695076","updated":"2026-07-27T12:54:55.695082","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccadccd4-0068-42ee-a08c-5c601259c89e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccadccd4-0068-42ee-a08c-5c601259c89e/pipeline.log\">pipeline</a>"]},{"id":"085aba7e-46e7-4e2c-826e-3efaa7975f86","name":"CentOS Stream 10 - postgresql-container","status":"complete","outcome":"passed","runTime":1253.328795,"created":"2026-07-27T12:30:37.321228","updated":"2026-07-27T12:30:37.321234","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/085aba7e-46e7-4e2c-826e-3efaa7975f86\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/085aba7e-46e7-4e2c-826e-3efaa7975f86/pipeline.log\">pipeline</a>"]},{"id":"249a9ce9-0d11-4ed4-bcc7-701371d43d3d","name":"RHEL11 - nginx-container","status":"complete","outcome":"error","runTime":358.645544,"created":"2026-07-27T12:40:59.717995","updated":"2026-07-27T12:40:59.718001","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/249a9ce9-0d11-4ed4-bcc7-701371d43d3d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/249a9ce9-0d11-4ed4-bcc7-701371d43d3d/pipeline.log\">pipeline</a>"]},{"id":"d264c96b-a98e-4a42-9c7d-ead1c67243ca","name":"CentOS Stream 11 - postgresql-container","status":"complete","outcome":"passed","runTime":805.85143,"created":"2026-07-27T12:30:35.906968","updated":"2026-07-27T12:30:35.906976","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d264c96b-a98e-4a42-9c7d-ead1c67243ca\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d264c96b-a98e-4a42-9c7d-ead1c67243ca/pipeline.log\">pipeline</a>"]},{"id":"9139caf6-62ef-4816-a49f-88e4cf9a3847","name":"CentOS Stream 10 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1384.880294,"created":"2026-07-27T12:30:35.848978","updated":"2026-07-27T12:30:35.848986","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9139caf6-62ef-4816-a49f-88e4cf9a3847\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9139caf6-62ef-4816-a49f-88e4cf9a3847/pipeline.log\">pipeline</a>"]},{"id":"902c22ef-f619-4a93-b416-c6016ca2f032","name":"Fedora - postgresql-container","status":"complete","outcome":"passed","runTime":1426.580712,"created":"2026-07-27T12:30:35.843907","updated":"2026-07-27T12:30:35.843914","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/902c22ef-f619-4a93-b416-c6016ca2f032\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/902c22ef-f619-4a93-b416-c6016ca2f032/pipeline.log\">pipeline</a>"]},{"id":"b5b6f9f9-82c4-46de-a729-a5d0556741c4","name":"CentOS Stream 11 - s2i-base-container","status":"complete","outcome":"passed","runTime":810.683411,"created":"2026-07-27T12:44:59.211245","updated":"2026-07-27T12:44:59.211253","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b5b6f9f9-82c4-46de-a729-a5d0556741c4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b5b6f9f9-82c4-46de-a729-a5d0556741c4/pipeline.log\">pipeline</a>"]},{"id":"4b2fb6a3-31c2-43f5-a063-dd59573b0768","name":"CentOS Stream 11 - nginx-container","status":"complete","outcome":"passed","runTime":801.406378,"created":"2026-07-27T12:43:28.174822","updated":"2026-07-27T12:43:28.174829","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4b2fb6a3-31c2-43f5-a063-dd59573b0768\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4b2fb6a3-31c2-43f5-a063-dd59573b0768/pipeline.log\">pipeline</a>"]},{"id":"dbdccc1e-cef9-4922-bbfb-3258d217b657","name":"RHEL10 - nginx-container","status":"complete","outcome":"error","runTime":323.495974,"created":"2026-07-27T12:45:09.708336","updated":"2026-07-27T12:45:09.708346","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbdccc1e-cef9-4922-bbfb-3258d217b657\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbdccc1e-cef9-4922-bbfb-3258d217b657/pipeline.log\">pipeline</a>"]},{"id":"9beeae69-87c3-41ff-a0d1-06c86633eccb","name":"CentOS Stream 10 - s2i-base-container","status":"complete","outcome":"passed","runTime":801.757091,"created":"2026-07-27T12:52:58.302936","updated":"2026-07-27T12:52:58.302943","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9beeae69-87c3-41ff-a0d1-06c86633eccb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9beeae69-87c3-41ff-a0d1-06c86633eccb/pipeline.log\">pipeline</a>"]},{"id":"4f25e97b-d822-4a02-90a6-60522507fabc","name":"CentOS Stream 11 - s2i-python-container","status":"complete","outcome":"passed","runTime":745.241092,"created":"2026-07-27T12:51:01.091757","updated":"2026-07-27T12:51:01.091765","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4f25e97b-d822-4a02-90a6-60522507fabc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4f25e97b-d822-4a02-90a6-60522507fabc/pipeline.log\">pipeline</a>"]},{"id":"9bc2d595-76cc-4e15-a270-cded5f5e45e4","name":"RHEL10 - s2i-python-container","status":"complete","outcome":"error","runTime":622.636793,"created":"2026-07-27T12:31:32.557580","updated":"2026-07-27T12:31:32.557588","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bc2d595-76cc-4e15-a270-cded5f5e45e4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bc2d595-76cc-4e15-a270-cded5f5e45e4/pipeline.log\">pipeline</a>"]},{"id":"9e78bc75-6b9a-4261-9045-142ea6973929","name":"CentOS Stream 9 - nginx-container","status":"complete","outcome":"passed","runTime":1087.72187,"created":"2026-07-27T12:30:38.079471","updated":"2026-07-27T12:30:38.079479","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9e78bc75-6b9a-4261-9045-142ea6973929\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9e78bc75-6b9a-4261-9045-142ea6973929/pipeline.log\">pipeline</a>"]},{"id":"55b593d9-eac0-4b1c-bb74-2d53ac4cacd4","name":"CentOS Stream 9 - s2i-perl-container","status":"complete","outcome":"passed","runTime":1453.044872,"created":"2026-07-27T12:44:55.286985","updated":"2026-07-27T12:44:55.286991","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/55b593d9-eac0-4b1c-bb74-2d53ac4cacd4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/55b593d9-eac0-4b1c-bb74-2d53ac4cacd4/pipeline.log\">pipeline</a>"]},{"id":"b3f113b6-b258-4cbb-92c3-0e2e4bcdbe25","name":"CentOS Stream 10 - nginx-container","status":"complete","outcome":"passed","runTime":869.671914,"created":"2026-07-27T12:30:35.877361","updated":"2026-07-27T12:30:35.877368","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b3f113b6-b258-4cbb-92c3-0e2e4bcdbe25\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b3f113b6-b258-4cbb-92c3-0e2e4bcdbe25/pipeline.log\">pipeline</a>"]},{"id":"4298e8c1-d527-464e-be55-a11659631d05","name":"CentOS Stream 9 - postgresql-container","status":"complete","outcome":"passed","runTime":1828.287883,"created":"2026-07-27T12:47:22.753274","updated":"2026-07-27T12:47:22.753283","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4298e8c1-d527-464e-be55-a11659631d05\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4298e8c1-d527-464e-be55-a11659631d05/pipeline.log\">pipeline</a>"]},{"id":"6ea04b09-f42a-46c0-abdc-9870efeae9ad","name":"CentOS Stream 9 - s2i-base-container","status":"complete","outcome":"passed","runTime":994.702322,"created":"2026-07-27T12:47:18.875381","updated":"2026-07-27T12:47:18.875392","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6ea04b09-f42a-46c0-abdc-9870efeae9ad\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6ea04b09-f42a-46c0-abdc-9870efeae9ad/pipeline.log\">pipeline</a>"]},{"id":"cc1dc568-2f91-4b1e-ae0d-17a0ee2591e3","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":2192.709393,"created":"2026-07-27T12:30:37.648809","updated":"2026-07-27T12:30:37.648819","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc1dc568-2f91-4b1e-ae0d-17a0ee2591e3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc1dc568-2f91-4b1e-ae0d-17a0ee2591e3/pipeline.log\">pipeline</a>"]},{"id":"cca55ef7-4b2e-42af-b854-f62e4626701d","name":"RHEL8 - postgresql-container","status":"complete","outcome":"passed","runTime":2452.668361,"created":"2026-07-27T12:44:49.729039","updated":"2026-07-27T12:44:49.729046","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cca55ef7-4b2e-42af-b854-f62e4626701d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cca55ef7-4b2e-42af-b854-f62e4626701d/pipeline.log\">pipeline</a>"]},{"id":"fb4462fd-b405-4930-b0a5-26b950e99722","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"passed","runTime":2841.209313,"created":"2026-07-27T12:47:07.277092","updated":"2026-07-27T12:47:07.277098","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb4462fd-b405-4930-b0a5-26b950e99722\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb4462fd-b405-4930-b0a5-26b950e99722/pipeline.log\">pipeline</a>"]},{"id":"d58315da-979c-4295-8045-489927037645","name":"Fedora - s2i-perl-container","status":"complete","outcome":"passed","runTime":2391.367967,"created":"2026-07-27T12:46:57.972900","updated":"2026-07-27T12:46:57.972906","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d58315da-979c-4295-8045-489927037645\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d58315da-979c-4295-8045-489927037645/pipeline.log\">pipeline</a>"]},{"id":"2679c9ab-9cb1-4046-8e36-70f15748f870","name":"CentOS Stream 10 - s2i-python-container","status":"complete","outcome":"passed","runTime":4524.074067,"created":"2026-07-27T12:48:55.363670","updated":"2026-07-27T12:48:55.363683","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2679c9ab-9cb1-4046-8e36-70f15748f870\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2679c9ab-9cb1-4046-8e36-70f15748f870/pipeline.log\">pipeline</a>"]},{"id":"b42ba47f-3611-48b7-a138-dc454c7dca2c","name":"Fedora - s2i-python-container","status":"complete","outcome":"passed","runTime":3824.367742,"created":"2026-07-27T12:30:40.718492","updated":"2026-07-27T12:30:40.718498","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b42ba47f-3611-48b7-a138-dc454c7dca2c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b42ba47f-3611-48b7-a138-dc454c7dca2c/pipeline.log\">pipeline</a>"]},{"id":"a5c0c1a4-9eea-43a5-a194-27c10e06f22e","name":"RHEL8 - s2i-python-container","status":"complete","outcome":"passed","runTime":4700.425258,"created":"2026-07-27T12:30:36.037102","updated":"2026-07-27T12:30:36.037140","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a5c0c1a4-9eea-43a5-a194-27c10e06f22e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a5c0c1a4-9eea-43a5-a194-27c10e06f22e/pipeline.log\">pipeline</a>"]},{"id":"003051f6-dacb-49d0-a1ae-3c9f360d3dad","name":"CentOS Stream 9 - s2i-python-container","runTime":5174.924947,"created":"2026-07-27T12:40:53.099777","updated":"2026-07-27T12:40:53.099784","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/003051f6-dacb-49d0-a1ae-3c9f360d3dad\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/003051f6-dacb-49d0-a1ae-3c9f360d3dad/pipeline.log\">pipeline</a>"]},{"id":"79cbac9e-f1e0-470a-b49e-3acb06166652","name":"RHEL11 - s2i-base-container","status":"complete","outcome":"error","runTime":380.034128,"created":"2026-07-27T12:38:50.288576","updated":"2026-07-27T12:38:50.288582","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/79cbac9e-f1e0-470a-b49e-3acb06166652\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/79cbac9e-f1e0-470a-b49e-3acb06166652/pipeline.log\">pipeline</a>"]},{"id":"49a103d7-df2d-421a-98cf-3a7cc6201bc3","name":"RHEL11 - s2i-python-container","status":"complete","outcome":"error","runTime":324.25849,"created":"2026-07-27T12:51:24.305771","updated":"2026-07-27T12:51:24.305778","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/49a103d7-df2d-421a-98cf-3a7cc6201bc3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/49a103d7-df2d-421a-98cf-3a7cc6201bc3/pipeline.log\">pipeline</a>"]},{"id":"8306c20f-0c80-4986-8f92-317f8e857ae7","name":"RHEL8 - nginx-container","status":"complete","outcome":"passed","runTime":2443.506853,"created":"2026-07-27T12:30:35.861807","updated":"2026-07-27T12:30:35.861817","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8306c20f-0c80-4986-8f92-317f8e857ae7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8306c20f-0c80-4986-8f92-317f8e857ae7/pipeline.log\">pipeline</a>"]}]} -->